### PR TITLE
Allow systemd to run scylla-jmx with params from /etc/defaults/

### DIFF
--- a/dist/common/sysconfig/scylla-jmx
+++ b/dist/common/sysconfig/scylla-jmx
@@ -3,3 +3,29 @@ SCYLLA_HOME=/var/lib/scylla
 
 # scylla config dir
 SCYLLA_CONF=/etc/scylla
+
+SCYLLA_PARAMS=""
+
+# The jmx port to open
+# SCYLLA_PARAMS="${SCYLLA_PARAMS } -jp 7199"
+
+# The API port to connect to
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} -p 12345"
+
+# API address to connect to
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} -a `hostname`"
+
+# use alternate jmx address
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} -ja `hostname`"
+
+# A configuration file to use
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} -cf /etc/scylla.d/scylla-user.cfg"
+
+# The location of the jmx proxy jar file
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} target /some/scripts"
+
+# allow to run remotely
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} -r"
+
+# allow debug
+# SCYLLA_PARAMS="${SCYLLA_PARAMS} -d"

--- a/dist/common/systemd/scylla-jmx.service.in
+++ b/dist/common/systemd/scylla-jmx.service.in
@@ -8,7 +8,7 @@ Type=simple
 EnvironmentFile=@@SYSCONFDIR@@/scylla-jmx
 User=scylla
 Group=scylla
-ExecStart=/usr/lib/scylla/jmx/scylla-jmx -l /usr/lib/scylla/jmx
+ExecStart=/usr/lib/scylla/jmx/scylla-jmx -l /usr/lib/scylla/jmx ${SCYLLA_PARAMS}
 KillMode=process
 Restart=on-abnormal
 


### PR DESCRIPTION
Using systemd to run scylla-jmx won't load params from /etc/defaults/scylla-jmx  because it expects params to be sent using the command line.

This patch enhances the sysconfig file by adding the available options (commented) and passes the right options to systemd `ExecStart` when defined. That way scylla-jmx is ran with the params defined into /etc/defaults/scylla-jmx.

Maybe not the most elegant way to do it, but 1/ it works 2/ I didn't find a better solution to fix that problem.