### PR TITLE
ColumnFamilyStore: finishLocalSampling should respect count limit

### DIFF
--- a/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -519,8 +519,8 @@ public class ColumnFamilyStore extends MetricsMBean implements ColumnFamilyStore
         JsonArray counters = tableSamplerResult.getJsonArray((samplerType.equalsIgnoreCase("reads")) ? "read" : "write");
         long size = 0;
         if (counters != null) {
-            size = counters.size();
-            for (int i = 0; i < counters.size(); i++) {
+            size = (count > counters.size()) ? counters.size() : count;
+            for (int i = 0; i < size; i++) {
                 JsonObject counter = counters.getJsonObject(i);
                 result.put(new CompositeDataSupport(COUNTER_COMPOSITE_TYPE, COUNTER_NAMES,
                         new Object[] { counter.getString("partition"), // raw


### PR DESCRIPTION
When calling nodetool toppartitions with size limit, finishLocalSampling
should respect that and limit the number of the results.

Example:
$ nodetool toppartitions -k 2 keyspace1 standard1 20
WRITES Sampler:
  Cardinality: ~2 (256 capacity)
  Top 2 partitions:
	Partition                Count       +/-
	38333032394d4f4d5030         4         3
	4e353937383137503330         4         3

READS Sampler:
  Cardinality: ~2 (256 capacity)
  Top 2 partitions:
	Nothing recorded during sampling period...

Fixes #66

Signed-off-by: Amnon Heiman <amnon@scylladb.com>