### PR TITLE
ColumnFamilyStore: Mbean API support the hex format param

### DIFF
--- a/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -369,6 +369,23 @@ public class ColumnFamilyStore extends MetricsMBean implements ColumnFamilyStore
     }
 
     /**
+     * Returns a list of filenames that contain the given key on this node
+     * @param key
+     * @param hexFormat if key is in hex string format
+     * @return list of filenames containing the key
+     */
+    @Override
+    public List<String> getSSTablesForKey(String key, boolean hexFormat)
+    {
+        log(" getSSTablesForKey(String key)");
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+        queryParams.add("key", key);
+        if (hexFormat) {
+            queryParams.add("format", "hex");
+        }
+        return client.getListStrValue("column_family/sstables/by_key/" + getCFName(), queryParams);
+    }
+    /**
      * Scan through Keyspace/ColumnFamily's data directory determine which
      * SSTables should be loaded and load them
      */

--- a/src/main/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
+++ b/src/main/java/org/apache/cassandra/db/ColumnFamilyStoreMBean.java
@@ -142,6 +142,14 @@ public interface ColumnFamilyStoreMBean {
     public List<String> getSSTablesForKey(String key);
 
     /**
+     * Returns a list of filenames that contain the given key on this node
+     * @param key
+     * @param hexFormat if key is in hex string format
+     * @return list of filenames containing the key
+     */
+    public List<String> getSSTablesForKey(String key, boolean hexFormat);
+
+    /**
      * Scan through Keyspace/ColumnFamily's data directory determine which
      * SSTables should be loaded and load them
      */


### PR DESCRIPTION
Cassandra 3.0 version of the JMX added a parameter that allows accepting
the parameter as hex.

This breaks the current implementation with a NoSuchMethodException.

This patch adds the missing implementation.

For a full support, a follow up patch in Scylla is needed, but for the
current functionality it would work.

After this patch usage example:

nodetool getsstables keyspace1 standard1 39303138374b4d343830

Signed-off-by: Amnon Heiman <amnon@scylladb.com>