### PR TITLE
Implement sstable_info command

### DIFF
--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -60,6 +60,21 @@
             <artifactId>activation</artifactId>
             <version>1.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>2.9.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scylla-apiclient/src/main/java/com/scylladb/jmx/api/APIClient.java
+++ b/scylla-apiclient/src/main/java/com/scylladb/jmx/api/APIClient.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.client.ClientConfig;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.scylladb.jmx.utils.SnapshotDetailsTabularData;
 
 public class APIClient {
@@ -78,9 +79,12 @@ public class APIClient {
     private static final Logger logger = Logger.getLogger(APIClient.class.getName());
 
     private final APIConfig config;
+    private final ClientConfig clientConfig;
 
     public APIClient(APIConfig config) {
         this.config = config;
+        this.clientConfig = new ClientConfig();
+        clientConfig.register(new JacksonJaxbJsonProvider());
     }
 
     private String getBaseUrl() {
@@ -88,7 +92,7 @@ public class APIClient {
     }
 
     public Invocation.Builder get(String path, MultivaluedMap<String, String> queryParams) {
-        Client client = ClientBuilder.newClient(new ClientConfig());
+        Client client = ClientBuilder.newClient(clientConfig);
         WebTarget webTarget = client.target(getBaseUrl()).path(path);
         if (queryParams != null) {
             for (Entry<String, List<String>> qp : queryParams.entrySet()) {

--- a/src/main/java/com/scylladb/jmx/utils/DateXmlAdapter.java
+++ b/src/main/java/com/scylladb/jmx/utils/DateXmlAdapter.java
@@ -1,0 +1,19 @@
+package com.scylladb.jmx.utils;
+
+import java.time.Instant;
+import java.util.Date;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public class DateXmlAdapter extends XmlAdapter<String, Date> {
+    @Override
+    public String marshal(Date v) throws Exception {
+        return Instant.ofEpochMilli(v.getTime()).toString();
+    }
+
+    @Override
+    public Date unmarshal(String v) throws Exception {
+        return new Date(Instant.parse(v).toEpochMilli());
+    }
+
+}

--- a/src/main/java/org/apache/cassandra/service/PerTableSSTableInfo.java
+++ b/src/main/java/org/apache/cassandra/service/PerTableSSTableInfo.java
@@ -1,0 +1,66 @@
+package org.apache.cassandra.service;
+
+import static com.sun.jmx.mbeanserver.MXBeanMappingFactory.DEFAULT;
+
+import java.io.InvalidObjectException;
+import java.util.List;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.OpenDataException;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.sun.jmx.mbeanserver.MXBeanMapping;
+
+@SuppressWarnings("restriction")
+@XmlRootElement
+public class PerTableSSTableInfo {
+    private static final MXBeanMapping mxBeanMapping;
+
+    static {
+        try {
+            mxBeanMapping = DEFAULT.mappingForType(PerTableSSTableInfo.class, DEFAULT);
+        } catch (OpenDataException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String keyspace;
+    private List<SSTableInfo> sstables;
+    private String table;
+
+    public String getTable() {
+        return table;
+    }
+
+    public void setTable(String table) {
+        this.table = table;
+    }
+
+    public String getKeyspace() {
+        return keyspace;
+    }
+
+    public void setKeyspace(String keyspace) {
+        this.keyspace = keyspace;
+    }
+
+    public List<SSTableInfo> getSSTables() {
+        return sstables;
+    }
+
+    public void setSSTableInfos(List<SSTableInfo> sstableInfos) {
+        this.sstables = sstableInfos;
+    }
+
+    public CompositeData toCompositeData() {
+        try {
+            return (CompositeData) mxBeanMapping.toOpenValue(this);
+        } catch (OpenDataException e) {
+            throw new Error(e); // should not reach.
+        }
+    }
+
+    public static PerTableSSTableInfo from(CompositeData data) throws InvalidObjectException {
+        return (PerTableSSTableInfo) mxBeanMapping.fromOpenValue(data);
+    }
+}

--- a/src/main/java/org/apache/cassandra/service/SSTableInfo.java
+++ b/src/main/java/org/apache/cassandra/service/SSTableInfo.java
@@ -1,0 +1,143 @@
+package org.apache.cassandra.service;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.scylladb.jmx.utils.DateXmlAdapter;
+
+public class SSTableInfo {
+    private long size;
+
+    @JsonProperty("data_size")
+    private long dataSize;
+
+    @JsonProperty("index_size")
+    private long indexSize;
+
+    @JsonProperty("filter_size")
+    private long filterSize;
+
+    @XmlJavaTypeAdapter(type = Date.class, value = DateXmlAdapter.class)
+    private Date timestamp;
+
+    private long generation;
+
+    private long level;
+
+    private String version;
+
+    private Map<String, String> properties;
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+
+    @JsonIgnore
+    private Map<String, Map<String, String>> extendedProperties;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public long getDataSize() {
+        return dataSize;
+    }
+
+    public void setDataSize(long dataSize) {
+        this.dataSize = dataSize;
+    }
+
+    public long getIndexSize() {
+        return indexSize;
+    }
+
+    public void setIndexSize(long indexSize) {
+        this.indexSize = indexSize;
+    }
+
+    public long getFilterSize() {
+        return filterSize;
+    }
+
+    public void setFilterSize(long filterSize) {
+        this.filterSize = filterSize;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    public void setGeneration(long generation) {
+        this.generation = generation;
+    }
+
+    public long getLevel() {
+        return level;
+    }
+
+    public void setLevel(long level) {
+        this.level = level;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public Map<String, Map<String, String>> getExtendedProperties() {
+        return extendedProperties;
+    }
+
+    public void setExtendedProperties(Map<String, Map<String, String>> extendedProperties) {
+        this.extendedProperties = extendedProperties;
+    }
+
+    @JsonProperty("extended_properties")
+    private void unpackNested(List<Map<String, Object>> properties) {
+        Map<String, Map<String, String>> result = new HashMap<String, Map<String, String>>();
+
+        for (Map<String, Object> map : properties) {
+            Object name = map.get("group");
+            if (name != null) {
+                Map<String, String> dst = new HashMap<>();
+                List<?> value = (List<?>) map.get("attributes");
+                for (Object v : value) {
+                    Map<?, ?> subMap = (Map<?, ?>) v;
+                    dst.put(String.valueOf(subMap.get("key")), String.valueOf(subMap.get("value")));
+                }
+                result.put(String.valueOf(name), dst);
+            } else {
+                for (Map.Entry<String, Object> e : map.entrySet()) {
+                    result.put(e.getKey(), Collections.singletonMap(String.valueOf(e.getValue()), ""));
+                }
+            }
+        }
+        extendedProperties = result;
+    }
+}

--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import javax.management.NotificationEmitter;
+import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
 public interface StorageServiceMBean extends NotificationEmitter {
@@ -872,4 +873,8 @@ public interface StorageServiceMBean extends NotificationEmitter {
      * Sets the hinted handoff throttle in kb per second, per delivery thread.
      */
     public boolean resumeBootstrap();
+    
+    public List<CompositeData> getSSTableInfo(String keyspace, String table);
+
+    public List<CompositeData> getSSTableInfo();
 }


### PR DESCRIPTION
Fixes #76 

Implements JMX level call for "sstable_info" REST api command.

Requires seastar patch:
 json: Make date formatter use RFC8601/RFC3339 format

Requires scylla patch set "Implement `sstable_info` API command (info on sstables)"

Forwards call to REST sstable_info and packs the data
into CompositeData for JMX consumption.