### PR TITLE
run scylla-jmx in a systemd slice

### DIFF
--- a/dist/common/systemd/scylla-jmx.service
+++ b/dist/common/systemd/scylla-jmx.service
@@ -11,6 +11,7 @@ Group=scylla
 ExecStart=/opt/scylladb/jmx/scylla-jmx $SCYLLA_JMX_PORT $SCYLLA_API_PORT $SCYLLA_API_ADDR $SCYLLA_JMX_ADDR $SCYLLA_JMX_FILE $SCYLLA_JMX_LOCAL $SCYLLA_JMX_REMOTE $SCYLLA_JMX_DEBUG
 KillMode=process
 Restart=on-abnormal
+Slice=scylla-helper.slice
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Scylla now supports server-defined systemd slices that are used to provide
isolation between components.

This patch adds scylla-jmx to the helper slice. This will guarantee that
scylla-jmx does not use too much resources, influencing the server performance.

Signed-off-by: Glauber Costa <glauber@scylladb.com>