### PR TITLE
build_deb.sh: don't generate scylla-jmx.service from mustache template

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -121,6 +121,6 @@ pystache dist/debian/rules.mustache "{ $MUSTACHE_DIST }" > debian/rules
 chmod a+rx debian/rules
 pystache dist/debian/control.mustache "{ $MUSTACHE_DIST }" > debian/control
 
-pystache dist/common/systemd/scylla-jmx.service.mustache "{ $MUSTACHE_DIST }" > debian/scylla-jmx.service
+cp dist/common/systemd/scylla-jmx.service debian/scylla-jmx.service
 
 debuild -rfakeroot -us -uc


### PR DESCRIPTION
Takuya had untemplataize scylla-jmx.service in commit e8355087ead4bded8f31ee8746f36dc097d5f7a1
But the build_deb.sh still tries to generate service file from a deleted
mustache template file -- scylla-jmx.spec.mustache. It wrongly redirects
a path to service file, then scylla-jmx would fail to start.

Fixes #80

Signed-off-by: Amos Kong <amos@scylladb.com>

/CC @syuu1228 