### PR TITLE
dist: drop symlink to scripts

### DIFF
--- a/dist/redhat/scylla-jmx.spec.mustache
+++ b/dist/redhat/scylla-jmx.spec.mustache
@@ -60,7 +60,6 @@ rm -rf $RPM_BUILD_ROOT
 /opt/scylladb/jmx/scylla-jmx
 /opt/scylladb/jmx/scylla-jmx-1.0.jar
 /opt/scylladb/jmx/symlinks/scylla-jmx
-/opt/scylladb/scripts/jmx
 
 %changelog
 * Fri Aug  7 2015 Takuya ASADA Takuya ASADA <syuu@cloudius-systems.com>

--- a/install.sh
+++ b/install.sh
@@ -124,8 +124,6 @@ fi
 install -m644 scylla-jmx-1.0.jar "$rprefix/jmx"
 install -m755 scylla-jmx "$rprefix/jmx"
 ln -sf /usr/bin/java "$rprefix/jmx/symlinks/scylla-jmx"
-# create symlink for /usr/lib/scylla/jmx
-ln -srf $rprefix/jmx "$rprefix/scripts/"
 
 if $nonroot; then
     sed -i -e "s#/var/lib/scylla#$rprefix#g" "$rsysconfdir"/scylla-jmx


### PR DESCRIPTION
This is scylla-jmx part of https://github.com/scylladb/scylla/pull/5530

After we stopped replacing /usr/lib/scylla with symlink,
creating symlink on /opt/scylladb/scripts/jmx become meaningless,
so we can drop it now.

We able to introduce new symlink on /usr/lib/scylla, but it likely no user
directly invoke scripts under /usr/lib/scylla/jmx, so we don't have to
do that.