### PR TITLE
dist: add /usr/lib/scylla/jmx for compatibility

### DIFF
--- a/dist/redhat/scylla-jmx.spec.mustache
+++ b/dist/redhat/scylla-jmx.spec.mustache
@@ -60,6 +60,9 @@ rm -rf $RPM_BUILD_ROOT
 /opt/scylladb/jmx/scylla-jmx
 /opt/scylladb/jmx/scylla-jmx-1.0.jar
 /opt/scylladb/jmx/symlinks/scylla-jmx
+%{_prefix}/lib/scylla/jmx/scylla-jmx
+%{_prefix}/lib/scylla/jmx/scylla-jmx-1.0.jar
+%{_prefix}/lib/scylla/jmx/symlinks/scylla-jmx
 
 %changelog
 * Fri Aug  7 2015 Takuya ASADA Takuya ASADA <syuu@cloudius-systems.com>

--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,12 @@ fi
 install -m644 scylla-jmx-1.0.jar "$rprefix/jmx"
 install -m755 scylla-jmx "$rprefix/jmx"
 ln -sf /usr/bin/java "$rprefix/jmx/symlinks/scylla-jmx"
+if ! $nonroot; then
+    install -m755 -d "$rusr"/lib/scylla/jmx/symlinks
+    ln -srf "$rprefix"/jmx/scylla-jmx-1.0.jar "$rusr"/lib/scylla/jmx/
+    ln -srf "$rprefix"/jmx/scylla-jmx "$rusr"/lib/scylla/jmx/
+    ln -sf /usr/bin/java "$rusr"/lib/scylla/jmx/symlinks/scylla-jmx
+fi
 
 if $nonroot; then
     sed -i -e "s#/var/lib/scylla#$rprefix#g" "$rsysconfdir"/scylla-jmx


### PR DESCRIPTION
On the commit 4c8660d, we dropped /usr/lib/scylla/jmx since it likely no user
script invoke scripts under the directory.
However, we found there are possibility scylla-jmx.service tries to load .jar
file from /usr/lib/scylla/jmx, when user upgraded from older version of scylla.
Because /etc/sysconfig/scylla-jmx is marked as 'noreplace' on our rpm,
yum upgrade may keep old sysconfig file when it modified by user, that may
causes to load .jar from /usr/lib/scylla/jmx since we specify the path in the
sysconfig file.

To avoid the issue it's better to have symlinks on /usr/lib/scylla/jmx for
safety.

See #90