### PR TITLE
dist/redhat: call systemctl --daemon-reload when upgraded

### DIFF
--- a/dist/redhat/scylla-jmx.spec.mustache
+++ b/dist/redhat/scylla-jmx.spec.mustache
@@ -41,6 +41,7 @@ fi
 
 %post
 %systemd_post scylla-jmx.service
+/usr/bin/systemctl daemon-reload ||:
 
 %preun
 %systemd_preun scylla-jmx.service


### PR DESCRIPTION
Since %systemd_post does not call systemctl --daemon-reload, we need to call it
manually to apply changes.

Fixes #90