### PR TITLE
dist: allow specify JVM options from sysconfig

### DIFF
--- a/dist/common/sysconfig/scylla-jmx
+++ b/dist/common/sysconfig/scylla-jmx
@@ -27,3 +27,6 @@ SCYLLA_JMX_LOCAL="-l /opt/scylladb/jmx"
 
 # allow debug
 #SCYLLA_JMX_DEBUG="-d"
+
+# specify JVM options
+JAVA_TOOL_OPTIONS=""


### PR DESCRIPTION
Add SCYLLA_JMX_JVM_OPTS on sysconfig to specify JVM options.

fixes #58