### PR TITLE
dist/redhat: override systemd macros to CentOS7 version

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -69,6 +69,7 @@ RPMBUILD=$(readlink -f ../)
 mkdir -p $RPMBUILD/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
 ln -fv $RELOC_PKG $RPMBUILD/SOURCES/
+ln -fv dist/redhat/systemd.inc $RPMBUILD/SOURCES/
 pystache dist/redhat/scylla-jmx.spec.mustache "{ \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"product\": \"$PRODUCT\", \"$PRODUCT\": true }" > $RPMBUILD/SPECS/scylla-jmx.spec
 
 # this rpm can be install on both fedora / centos7, so drop distribution name from the file name

--- a/dist/redhat/scylla-jmx.spec.mustache
+++ b/dist/redhat/scylla-jmx.spec.mustache
@@ -7,12 +7,15 @@ Group:          Applications/Databases
 License:        AGPLv3
 URL:            http://www.scylladb.com/
 Source0:        scylla-jmx-package.tar.gz
+Source1:        systemd.inc
 
 BuildArch:      noarch
 BuildRequires:  systemd-units
 BuildRequires: pystache
 %{?rhel:BuildRequires: python-setuptools}
 Requires:       {{product}}-server java-1.8.0-openjdk-headless
+
+%include %{SOURCE1}
 
 %description
 
@@ -41,7 +44,6 @@ fi
 
 %post
 %systemd_post scylla-jmx.service
-/usr/bin/systemctl daemon-reload ||:
 
 %preun
 %systemd_preun scylla-jmx.service

--- a/dist/redhat/systemd.inc
+++ b/dist/redhat/systemd.inc
@@ -1,0 +1,19 @@
+%define systemd_daemon_reload \
+if [ -x /usr/bin/systemctl ]; then \
+    /usr/bin/systemctl daemon-reload ||: \
+fi \
+%{nil}
+
+%undefine systemd_post
+%define systemd_post() %{expand:%systemd_daemon_reload}
+
+%undefine systemd_preun
+%define systemd_preun() \
+if [ $1 -eq 0 ] && [ -x /usr/bin/systemctl ]; then \
+    /usr/bin/systemctl disable %1 ||: \
+    /usr/bin/systemctl stop %1 ||: \
+fi \
+%{nil}
+
+%undefine systemd_postun
+%define systemd_postun() %{expand:%systemd_daemon_reload}


### PR DESCRIPTION
Fedora 31 version of systemd macros does not work correctly on CentOS7,
since CentOS7 does not support "file trigger" feature.
Even after 05d4378, scriptlets on old scylla .rpm and new scylla .rpm is
not completely same.

To fix the issue we need to override macros with CentOS7 version.

Fixes #94