### PR TITLE
StorageService: Add the scrub 3.11 command implementation

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageService.java
+++ b/src/main/java/org/apache/cassandra/service/StorageService.java
@@ -645,7 +645,7 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
         APIClient.set_bool_query_param(queryParams, "disable_snapshot", disableSnapshot);
         APIClient.set_bool_query_param(queryParams, "skip_corrupted", skipCorrupted);
         APIClient.set_query_param(queryParams, "cf", APIClient.join(columnFamilies));
-        return client.getIntValue("/storage_service/keyspace_scrub/" + keyspaceName);
+        return client.getIntValue("/storage_service/keyspace_scrub/" + keyspaceName, queryParams);
     }
 
     /**
@@ -1669,7 +1669,7 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, int jobs, String keyspaceName,
             String... columnFamilies) throws IOException, ExecutionException, InterruptedException {
         // "jobs" not (yet) relevant for scylla. (though possibly useful...)
-        return scrub(disableSnapshot, skipCorrupted, checkData, 0, keyspaceName, columnFamilies);
+        return scrub(disableSnapshot, skipCorrupted, checkData, keyspaceName, columnFamilies);
     }
 
     @Override
@@ -1737,5 +1737,16 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
     @Override
     public List<CompositeData> getSSTableInfo() {
         return getSSTableInfo(null, null);
+    }
+
+    @Override
+    public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL,
+            int jobs, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+        APIClient.set_bool_query_param(queryParams, "disable_snapshot", disableSnapshot);
+        APIClient.set_bool_query_param(queryParams, "skip_corrupted", skipCorrupted);
+        APIClient.set_query_param(queryParams, "cf", APIClient.join(columnFamilies));
+        return client.getIntValue("/storage_service/keyspace_scrub/" + keyspaceName, queryParams);
     }
 }

--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -357,8 +357,13 @@ public interface StorageServiceMBean extends NotificationEmitter {
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, String keyspaceName,
             String... tableNames) throws IOException, ExecutionException, InterruptedException;
 
+    @Deprecated
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, int jobs, String keyspaceName,
             String... columnFamilies) throws IOException, ExecutionException, InterruptedException;
+
+    public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL,
+            int jobs, String keyspaceName, String... columnFamilies)
+            throws IOException, ExecutionException, InterruptedException;
 
     /**
      * Verify (checksums of) the given keyspace. If tableNames array is empty,


### PR DESCRIPTION
The scrub command was not supported from node_tool, but now when we want
to enable it the current API is not compatible with the 3.11 MBean
definition.

This patch adds the definition to the MBean and the implementation to
StorageService.

It also addresses two problems with the old scrub implementation, just
in case someone will use them.

1. Implementation didn't pass the parameters to the API.
2. A stub implementation called itself instead of calling an actual
implementation.

This patch will enable to test the command from nodetool additional
changes may come on top of it if more command line options will be
supported.

Relates to scylladb/scylla#6072

Signed-off-by: Amnon Heiman <amnon@scylladb.com>
