### PR TITLE
reloc-pkg: move all files under project name directory

### DIFF
--- a/dist/redhat/scylla-jmx.spec.mustache
+++ b/dist/redhat/scylla-jmx.spec.mustache
@@ -18,7 +18,7 @@ Requires:       {{product}}-server java-1.8.0-openjdk-headless
 
 
 %prep
-%setup -c
+%setup -n scylla-jmx-package
 
 
 %build

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -25,7 +25,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/debian/scylla-package
-tar -C build/debian/scylla-package -xpf $RELOC_PKG
-cd build/debian/scylla-package
+mkdir -p build/debian
+tar -C build/debian -xpf $RELOC_PKG
+cd build/debian/scylla-jmx-package
 exec ./dist/debian/build_deb.sh $OPTS

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -24,7 +24,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/redhat/scylla-package
-tar -C build/redhat/scylla-package -xpf $RELOC_PKG SCYLLA-RELEASE-FILE SCYLLA-RELOCATABLE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat
-cd build/redhat/scylla-package
+mkdir -p build/redhat
+tar -C build/redhat/ -xpf $RELOC_PKG scylla-jmx-package/SCYLLA-RELEASE-FILE scylla-jmx-package/SCYLLA-RELOCATABLE-FILE scylla-jmx-package/SCYLLA-VERSION-FILE scylla-jmx-package/SCYLLA-PRODUCT-FILE scylla-jmx-package/dist/redhat
+cd build/redhat/scylla-jmx-package
 exec ./dist/redhat/build_rpm.sh $OPTS

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -27,6 +27,14 @@ import os
 import tarfile
 import pathlib
 
+RELOC_PREFIX='scylla-jmx-package'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+
+tarfile.TarFile.reloc_add = reloc_add
 
 ap = argparse.ArgumentParser(description='Create a relocatable scylla package.')
 ap.add_argument('dest',
@@ -38,13 +46,13 @@ output = args.dest
 
 ar = tarfile.open(output, mode='w|gz')
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
-ar.add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
-ar.add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
-ar.add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
-ar.add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
-ar.add('dist')
-ar.add('install.sh')
-ar.add('target/scylla-jmx-1.0.jar', arcname='scylla-jmx-1.0.jar')
-ar.add('scripts/scylla-jmx', arcname='scylla-jmx')
-ar.add('README.md')
-ar.add('NOTICE')
+ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
+ar.reloc_add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
+ar.reloc_add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
+ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('dist')
+ar.reloc_add('install.sh')
+ar.reloc_add('target/scylla-jmx-1.0.jar', arcname='scylla-jmx-1.0.jar')
+ar.reloc_add('scripts/scylla-jmx', arcname='scylla-jmx')
+ar.reloc_add('README.md')
+ar.reloc_add('NOTICE')


### PR DESCRIPTION
To make unified relocatable package easily, we may want to merge tarballs to single tarball like this:
zcat .tar.gz | gzip -c > scylla-unified.tar.xz
But it's not possible with current relocatable package format, since there are multiple files conflicts, install.sh, SCYLLA--FILE, dist/, README.md, etc..

To support this, we need to archive everything in the directory when building relocatable package.

See: scylladb/scylla#6315