### PR TITLE
dist/redhat: drop dependency on pystache

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -53,13 +53,6 @@ fi
 if [ ! -f /usr/bin/git ]; then
     pkg_install git
 fi
-if [ ! -f /usr/bin/pystache ]; then
-    if is_redhat_variant; then
-        sudo yum install -y python2-pystache || sudo yum install -y pystache
-    elif is_debian_variant; then
-        sudo apt-get install -y python-pystache
-    fi
-fi
 
 SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
@@ -69,7 +62,13 @@ RPMBUILD=$(readlink -f ../)
 mkdir -p $RPMBUILD/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
 ln -fv $RELOC_PKG $RPMBUILD/SOURCES/
-pystache dist/redhat/scylla-jmx.spec.mustache "{ \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"product\": \"$PRODUCT\", \"$PRODUCT\": true }" > $RPMBUILD/SPECS/scylla-jmx.spec
 
+parameters=(
+    -D"version $SCYLLA_VERSION"
+    -D"release $SCYLLA_RELEASE"
+    -D"product $PRODUCT"
+)
+
+cp dist/redhat/scylla-jmx.spec $RPMBUILD/SPECS
 # this rpm can be install on both fedora / centos7, so drop distribution name from the file name
-rpmbuild -ba --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" --undefine "dist" $RPM_JOBS_OPTS $RPMBUILD/SPECS/scylla-jmx.spec
+rpmbuild -ba "${parameters[@]}" --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" --undefine "dist" $RPM_JOBS_OPTS $RPMBUILD/SPECS/scylla-jmx.spec

--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -1,6 +1,6 @@
-Name:           {{product}}-jmx
-Version:        {{version}}
-Release:        {{release}}%{?dist}
+Name:           %{product}-jmx
+Version:        %{version}
+Release:        %{release}%{?dist}
 Summary:        Scylla JMX
 Group:          Applications/Databases
 
@@ -10,9 +10,7 @@ Source0:        scylla-jmx-package.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  systemd-units
-BuildRequires: pystache
-%{?rhel:BuildRequires: python-setuptools}
-Requires:       {{product}}-server java-1.8.0-openjdk-headless
+Requires:       %{product}-server java-1.8.0-openjdk-headless
 
 %description
 


### PR DESCRIPTION
Same as https://github.com/scylladb/scylla/pull/6313, drop dependency on
pystache since it nolong present in Fedora 32.