### PR TITLE
reloc-pkg: move all files under project name directory

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PRODUCT=$(cat SCYLLA-PRODUCT-FILE)
+PRODUCT=$(cat scylla-jmx/SCYLLA-PRODUCT-FILE)
 
 . /etc/os-release
 print_usage() {
@@ -39,7 +39,7 @@ pkg_install() {
     fi
 }
 
-if [ ! -e SCYLLA-RELOCATABLE-FILE ]; then
+if [ ! -e scylla-jmx/SCYLLA-RELOCATABLE-FILE ]; then
     echo "do not directly execute build_rpm.sh, use reloc/build_rpm.sh instead."
     exit 1
 fi
@@ -91,8 +91,10 @@ fi
 
 RELOC_PKG_FULLPATH=$(readlink -f $RELOC_PKG)
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
-SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE | sed 's/\.rc/~rc/')
-SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
+SCYLLA_VERSION=$(cat scylla-jmx/SCYLLA-VERSION-FILE | sed 's/\.rc/~rc/')
+SCYLLA_RELEASE=$(cat scylla-jmx/SCYLLA-RELEASE-FILE)
 
 ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-jmx_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
+
+cp -al scylla-jmx/debian debian
 debuild -rfakeroot -us -uc

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -8,7 +8,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	./install.sh --root "$(CURDIR)/debian/$(DEB_SOURCE)" --sysconfdir /etc/default
+	cd scylla-jmx; ./install.sh --root "$(CURDIR)/debian/$(DEB_SOURCE)" --sysconfdir /etc/default
 
 override_dh_installinit:
 ifeq ($(DEB_SOURCE),scylla-jmx)

--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -16,7 +16,7 @@ Requires:       %{product}-server java-1.8.0-openjdk-headless
 
 
 %prep
-%setup -c
+%setup -n scylla-jmx
 
 
 %build

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -28,4 +28,4 @@ fi
 mkdir -p build/debian/scylla-package
 tar -C build/debian/scylla-package -xpf $RELOC_PKG
 cd build/debian/scylla-package
-exec ./dist/debian/build_deb.sh $OPTS
+exec ./scylla-jmx/dist/debian/build_deb.sh $OPTS

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -24,7 +24,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/redhat/scylla-package
-tar -C build/redhat/scylla-package -xpf $RELOC_PKG SCYLLA-RELEASE-FILE SCYLLA-RELOCATABLE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat
-cd build/redhat/scylla-package
+mkdir -p build/redhat
+tar -C build/redhat/ -xpf $RELOC_PKG scylla-jmx/SCYLLA-RELEASE-FILE scylla-jmx/SCYLLA-RELOCATABLE-FILE scylla-jmx/SCYLLA-VERSION-FILE scylla-jmx/SCYLLA-PRODUCT-FILE scylla-jmx/dist/redhat
+cd build/redhat/scylla-jmx
 exec ./dist/redhat/build_rpm.sh $OPTS

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -27,6 +27,14 @@ import os
 import tarfile
 import pathlib
 
+RELOC_PREFIX='scylla-jmx'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+
+tarfile.TarFile.reloc_add = reloc_add
 
 ap = argparse.ArgumentParser(description='Create a relocatable scylla package.')
 ap.add_argument('dest',
@@ -37,15 +45,20 @@ args = ap.parse_args()
 output = args.dest
 
 ar = tarfile.open(output, mode='w|gz')
+# relocatable package format version = 2
+with open('build/.relocatable_package_version', 'w') as f:
+    f.write('2\n')
+ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
+
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
-ar.add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
-ar.add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
-ar.add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
-ar.add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
-ar.add('dist')
-ar.add('install.sh')
-ar.add('target/scylla-jmx-1.0.jar', arcname='scylla-jmx-1.0.jar')
-ar.add('scripts/scylla-jmx', arcname='scylla-jmx')
-ar.add('README.md')
-ar.add('NOTICE')
-ar.add('build/debian/debian', arcname='debian')
+ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
+ar.reloc_add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
+ar.reloc_add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
+ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('dist')
+ar.reloc_add('install.sh')
+ar.reloc_add('target/scylla-jmx-1.0.jar', arcname='scylla-jmx-1.0.jar')
+ar.reloc_add('scripts/scylla-jmx', arcname='scylla-jmx')
+ar.reloc_add('README.md')
+ar.reloc_add('NOTICE')
+ar.reloc_add('build/debian/debian', arcname='debian')


### PR DESCRIPTION
*this is reopened version of https://github.com/scylladb/scylla-jmx/pull/102, since it dequeued*

To make unified relocatable package easily, we may want to merge tarballs to single tarball like this:
zcat .tar.gz | gzip -c > scylla-unified.tar.xz
But it's not possible with current relocatable package format, since there are multiple files conflicts, install.sh, SCYLLA--FILE, dist/, README.md, etc..

To support this, we need to archive everything in the directory when building relocatable package.

See: scylladb/scylla#6315