### PR TITLE
dist/debian: don't install systemd unit by install.sh, use debian/*.service

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -8,7 +8,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd scylla-jmx; ./install.sh --root "$(CURDIR)/debian/$(DEB_SOURCE)" --sysconfdir /etc/default
+	cd scylla-jmx; ./install.sh --root "$(CURDIR)/debian/$(DEB_SOURCE)" --sysconfdir /etc/default --skip-service
 
 override_dh_installinit:
 ifeq ($(DEB_SOURCE),scylla-jmx)

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ Options:
   --prefix /prefix         directory prefix (default /usr)
   --nonroot                shortcut of '--disttype nonroot'
   --sysconfdir /etc/sysconfig   specify sysconfig directory name
+  --skip-service           skip installing systemd .service files
   --help                   this helpful message
 EOF
     exit 1
@@ -39,6 +40,7 @@ EOF
 root=/
 sysconfdir=/etc/sysconfig
 nonroot=false
+skip_service=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -57,6 +59,10 @@ while [ $# -gt 0 ]; do
         "--sysconfdir")
             sysconfdir="$2"
             shift 2
+            ;;
+        "--skip-service")
+            skip_service=true
+            shift 1
             ;;
         "--help")
             shift 1
@@ -93,7 +99,9 @@ install -d -m755 "$rsystemd"
 install -d -m755 "$rprefix/scripts" "$rprefix/jmx" "$rprefix/jmx/symlinks"
 
 install -m644 dist/common/sysconfig/scylla-jmx -Dt "$rsysconfdir"
-install -m644 dist/common/systemd/scylla-jmx.service  -Dt "$rsystemd"
+if ! $skip_service; then
+    install -m644 dist/common/systemd/scylla-jmx.service  -Dt "$rsystemd"
+fi
 if ! $nonroot; then
     if [ "$sysconfdir" != "/etc/sysconfig" ]; then
         install -d -m755 "$retc"/systemd/system/scylla-jmx.service.d


### PR DESCRIPTION
Installing *.service by install.sh script causes the error on installing .deb
package, use debian/*.service instead.

Fixes scylladb/scylla#6010
Related scylladb/scylla#5640
Related https://github.com/scylladb/scylla/commit/29285b28e2de2f07593a65a5f03977da440b2e42