### PR TITLE
dist/debian: don't install systemd unit by install.sh, use debian/*.service

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -8,7 +8,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd scylla-jmx; ./install.sh --root "$(CURDIR)/debian/$(DEB_SOURCE)" --sysconfdir /etc/default
+	cd scylla-jmx; ./install.sh --root "$(CURDIR)/debian/tmp" --sysconfdir /etc/default
 
 override_dh_installinit:
 ifeq ($(DEB_SOURCE),scylla-jmx)

--- a/dist/debian/debian/scylla-jmx.install
+++ b/dist/debian/debian/scylla-jmx.install
@@ -1,0 +1,4 @@
+etc/default/scylla-jmx
+etc/systemd/system/scylla-jmx.service.d/sysconfdir.conf
+opt/scylladb/jmx/*
+usr/lib/scylla/jmx/*


### PR DESCRIPTION
Installing *.service by install.sh script causes the error on installing .deb
package, use debian/*.service instead.

Fixes scylladb/scylla#6010
Related scylladb/scylla#5640
Related https://github.com/scylladb/scylla/commit/29285b28e2de2f07593a65a5f03977da440b2e42