### PR TITLE
dist/debian: cleanup build/debian before building .deb

### DIFF
--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -25,6 +25,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
+rm -rf build/debian
 mkdir -p build/debian/scylla-package
 tar -C build/debian/scylla-package -xpf $RELOC_PKG
 cd build/debian/scylla-package


### PR DESCRIPTION
On 52bd496, we stopped to rm -rf debian/ on build_deb.sh, since now we have
prebuilt debian/ directory.
However, it might cause .deb build error when we modified debian package source,
since it never cleanup.

To prevent build error, we need to cleanup build/debian on reloc/build_deb.sh,
before extracting contents from relocatable package.