### PR TITLE
dist: add --packaging for .rpm/.deb build

### DIFF
--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -8,7 +8,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd scylla-jmx; ./install.sh --root "$(CURDIR)/debian/tmp" --sysconfdir /etc/default
+	cd scylla-jmx; ./install.sh --packaging --root "$(CURDIR)/debian/tmp" --sysconfdir /etc/default
 
 override_dh_installinit:
 ifeq ($(DEB_SOURCE),scylla-jmx)

--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -22,7 +22,7 @@ Requires:       %{product}-server java-1.8.0-openjdk-headless
 %build
 
 %install
-./install.sh --root "$RPM_BUILD_ROOT"
+./install.sh --packaging --root "$RPM_BUILD_ROOT"
 
 %pre
 /usr/sbin/groupadd scylla 2> /dev/null || :


### PR DESCRIPTION
354df10 mistakenly does not contain dist/redhat & dist/debian change,
add --package option to them.