### PR TITLE
MetricsRegistry: Support both types of histograms

### DIFF
--- a/src/main/java/org/apache/cassandra/metrics/MetricsRegistry.java
+++ b/src/main/java/org/apache/cassandra/metrics/MetricsRegistry.java
@@ -654,7 +654,11 @@ public class MetricsRegistry {
         public void update(JsonObject obj) {
             // TODO: this is not atomic.
             super.update(obj.getJsonObject("meter"));
-            histogram = new Histogram(obj.getJsonObject("hist"));
+            if (obj.containsKey("hist")) {
+                histogram = new Histogram(obj.getJsonObject("hist"));
+            } else if (obj.containsKey("buckets")) {
+                histogram = new Histogram(new EstimatedHistogram(obj));
+            }
         }
 
         @Override


### PR DESCRIPTION
There are two types of histograms, the older deprecated histogram and
the new estimated_histogram.

This patch changes the implementation of MetricsRegistry so the JmxTimer
would support both types, similiar to JmxHistogram.

Fixes #117

Signed-off-by: Amnon Heiman <amnon@scylladb.com>