### PR TITLE
gitignore: fix typo and add scylla-apiclient/target/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
 /bin/
 dependency-reduced-pom.xml
+scylla-apiclient/target/
 .classpath
 .project
 .settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /target/
 /bin/
-dependecy-reduced-pom.xml
+dependency-reduced-pom.xml
 .classpath
 .project
 .settings
-


### PR DESCRIPTION
when building scylla-jmx in place `scylla-apiclient/target/` is left behind and should be ignored by `.gitignore` otherwise the scylla submodule directory appears to be dirty.