### PR TITLE
dist: redhat: reduce log spam from unpacking sources when building rpm

### DIFF
--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -16,7 +16,7 @@ Requires:       %{product}-server java-1.8.0-openjdk-headless
 
 
 %prep
-%setup -n scylla-jmx
+%setup -q -n scylla-jmx
 
 
 %build


### PR DESCRIPTION
rpmbuild defaults to logging the name of every file it unpacks from
the archive. This is quite a lot for Java applications.

Make it quiet with the %setup -q flag.