### PR TITLE
dist/common/systemd: set WorkingDirectory to get heap dump correctly

### DIFF
--- a/dist/common/systemd/scylla-jmx.service
+++ b/dist/common/systemd/scylla-jmx.service
@@ -12,6 +12,7 @@ ExecStart=/opt/scylladb/jmx/scylla-jmx $SCYLLA_JMX_PORT $SCYLLA_API_PORT $SCYLLA
 KillMode=process
 Restart=on-abnormal
 Slice=scylla-helper.slice
+WorkingDirectory=/var/lib/scylla
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently scylla-jmx.service's PWD is "/", we get following error when
JVM trying to write heap dump on current directory:

Aug 17 05:52:15 localhost.localdomain scylla-jmx[3469]: Starting the JMX server
Aug 17 05:52:16 localhost.localdomain scylla-jmx[3469]: java.lang.OutOfMemoryError: Java heap space
Aug 17 05:52:16 localhost.localdomain scylla-jmx[3469]: Dumping heap to java_pid3469.hprof ...
Aug 17 05:52:16 localhost.localdomain scylla-jmx[3469]: Unable to create java_pid3469.hprof: Permission denied

To fix this, we need to specify WorkingDirectory on systemd unit.

See scylladb/scylla-enterprise#1469