### PR TITLE
dist/debian/control.template:remove conflict tag for java 11 and add it as dependency 

### DIFF
--- a/dist/common/systemd/scylla-jmx.service
+++ b/dist/common/systemd/scylla-jmx.service
@@ -12,6 +12,7 @@ ExecStart=/opt/scylladb/jmx/scylla-jmx $SCYLLA_JMX_PORT $SCYLLA_API_PORT $SCYLLA
 KillMode=process
 Restart=on-abnormal
 Slice=scylla-helper.slice
+WorkingDirectory=/var/lib/scylla
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,8 +8,7 @@ Rules-Requires-Root: no
 
 Package: %{product}-jmx
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre, %{product}-server
-Conflicts: openjdk-11-jre-headless, openjdk-11-jre, oracle-java11-set-default
+Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre |oracle-java11-set-default , %{product}-server
 Description: Scylla JMX server binaries 
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.


### PR DESCRIPTION
Today before installing jmx we must have java-8 installed.
In Debian10 the default java is 11, Removing the conflict tag and adding java 11 to dependencies list
