### PR TITLE
fix offline installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,12 +78,12 @@ if ! $packaging; then
     has_java=false
     if [ -x /usr/bin/java ]; then
         javaver=$(/usr/bin/java -version 2>&1|head -n1|cut -f 3 -d " ")
-        if [[ "$javaver" =~ ^\"1.8.0 ]]; then
+        if [[ "$javaver" =~ ^\"1.8.0 || "$javaver" =~ ^\"11.0. ]]; then
             has_java=true
         fi
     fi
     if ! $has_java; then
-        echo "Please install openjdk-8 before running install.sh."
+        echo "Please install openjdk-8 or openjdk-11 before running install.sh."
         exit 1
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -133,6 +133,7 @@ ExecStart=
 ExecStart=$rprefix/jmx/scylla-jmx \$SCYLLA_JMX_PORT \$SCYLLA_API_PORT \$SCYLLA_API_ADDR \$SCYLLA_JMX_ADDR \$SCYLLA_JMX_FILE \$SCYLLA_JMX_LOCAL \$SCYLLA_JMX_REMOTE \$SCYLLA_JMX_DEBUG
 User=
 Group=
+WorkingDirectory=
 EOS
     if [ ! -d ~/.config/systemd/user/scylla-jmx.service.d ]; then
         mkdir -p ~/.config/systemd/user/scylla-jmx.service.d


### PR DESCRIPTION
Currently after offline installation, the scylla-jmx fails to be started.
This patch fixed the problem.


Fixes: https://github.com/scylladb/scylla/issues/7098 by [PATCH] install.sh: check both openjdk-8 and openjdk-11

Fixes: https://github.com/scylladb/scylla-jmx/issues/129 by [PATCH] nonroot.conf: set WorkingDirectory to empty