### PR TITLE
JMX footprint work

### DIFF
--- a/src/main/java/com/scylladb/jmx/metrics/RegistrationChecker.java
+++ b/src/main/java/com/scylladb/jmx/metrics/RegistrationChecker.java
@@ -1,0 +1,69 @@
+package com.scylladb.jmx.metrics;
+
+import static com.scylladb.jmx.metrics.RegistrationMode.Remove;
+import static com.scylladb.jmx.metrics.RegistrationMode.Wait;
+import static java.util.EnumSet.allOf;
+import static java.util.EnumSet.of;
+
+import java.net.UnknownHostException;
+import java.util.EnumSet;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.management.OperationsException;
+
+import com.scylladb.jmx.api.APIClient;
+import com.sun.jmx.mbeanserver.JmxMBeanServer;
+
+/**
+ * Helper type to do optional locking for registration. Allows for
+ * per-bind-point locks and registration, instead of per-type or per-instance
+ * locks which may be misguiding, since for example one instance can be bound to
+ * many MBeanServers etc.
+ * 
+ * Also allows for polled checks, i.e. try-lock and either wait or skip. Wait,
+ * because we probably should not repeat things hidden by this type too often,
+ * and skip because for example a periodic task checking can just skip if a
+ * user-initiated registration check is being done.
+ * 
+ * @author calle
+ *
+ */
+@SuppressWarnings("restriction")
+public abstract class RegistrationChecker {
+    private final Lock lock = new ReentrantLock();
+
+    public static final EnumSet<RegistrationMode> REMOVE_NO_WAIT = of(Remove);
+    public static final EnumSet<RegistrationMode> ADD_AND_REMOVE = allOf(RegistrationMode.class);
+
+    public final void reap(APIClient client, JmxMBeanServer server) throws OperationsException, UnknownHostException {
+        check(client, server, REMOVE_NO_WAIT);
+    }
+
+    public final void check(APIClient client, JmxMBeanServer server) throws OperationsException, UnknownHostException {
+        check(client, server, ADD_AND_REMOVE);
+    }
+
+    public final void check(APIClient client, JmxMBeanServer server, EnumSet<RegistrationMode> mode)
+            throws OperationsException, UnknownHostException {
+        if (!lock.tryLock()) {
+            if (mode.contains(Wait)) {
+                // someone is doing update.
+                // since this is jmx, and sloppy, we'll just
+                // assume that once he is done, things are
+                // good enough.
+                lock.lock();
+                lock.unlock();
+            }
+            return;
+        }
+        try {
+            doCheck(client, server, mode);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    protected abstract void doCheck(APIClient client, JmxMBeanServer server, EnumSet<RegistrationMode> mode)
+            throws OperationsException, UnknownHostException;
+}

--- a/src/main/java/com/scylladb/jmx/metrics/RegistrationMode.java
+++ b/src/main/java/com/scylladb/jmx/metrics/RegistrationMode.java
@@ -1,0 +1,5 @@
+package com.scylladb.jmx.metrics;
+
+public enum RegistrationMode {
+	Wait, Add, Remove,
+}

--- a/src/main/java/org/apache/cassandra/metrics/TableMetrics.java
+++ b/src/main/java/org/apache/cassandra/metrics/TableMetrics.java
@@ -19,6 +19,8 @@ package org.apache.cassandra.metrics;
 
 import static com.scylladb.jmx.api.APIClient.getReader;
 
+import java.io.InvalidObjectException;
+import java.io.ObjectStreamException;
 import java.util.Hashtable;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -295,7 +297,6 @@ public class TableMetrics implements Metrics {
         registry.createDummyTableGauge(Double.class, "PercentRepaired");
     }
 
-    @SuppressWarnings("serial")
     static class TableMetricObjectName extends javax.management.ObjectName {
         private final TableMetricStringNameFactory factory;
         private final String metricName;
@@ -400,6 +401,18 @@ public class TableMetrics implements Metrics {
         public boolean isPropertyValuePattern() {
             return false;
         }
+        
+        /**
+         * This type is not really serializable. 
+         * Replace it with vanilla objectname.
+         */
+		private Object writeReplace() throws ObjectStreamException {
+			try {
+				return new ObjectName(getDomain(), getKeyPropertyList());
+			} catch (MalformedObjectNameException e) {
+				throw new InvalidObjectException(toString());
+			}
+		}
     }
 
     static interface TableMetricStringNameFactory {


### PR DESCRIPTION
Fixes #133
Fixes #134 
Refs #135

Makes CF mbean refresh code synchronized and tries to remove reductant calls if we contend. 
Adds background reaping of dead objects to reduce memory load in (test) scenarios where we manage
to refresh to add, but not cause removal (i.e. no wildcard queries). 

TableMetricsObjectName serialization is fixed in the series because without it we see loads of 
exceptions when refreshing the mbean set. 