### PR TITLE
build: support passing product-version-release as a parameter

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -14,6 +14,34 @@ else
 	SCYLLA_RELEASE=$DATE.$GIT_COMMIT
 fi
 
+usage() {
+    echo "usage: $0"
+    echo "           [--version product-version-release]          # override p-v-r"
+    exit 1
+}
+
+OVERRIDE=
+while [[ $# > 0 ]]; do
+    case "$1" in
+	--version)
+	    OVERRIDE="$2"
+	    shift 2
+	    ;;
+	*)
+	    usage
+	    ;;
+    esac
+done
+
+if [[ -n "$OVERRIDE" ]]; then
+    # regular expression for p-v-r: alphabetic+dashes for product, trailing non-dashes
+    # for release, everything else for version
+    RE='^([-a-z]+)-(.+)-([^-]+)$'
+    PRODUCT="$(sed -E "s/$RE/\\1/" <<<"$OVERRIDE")"
+    SCYLLA_VERSION="$(sed -E "s/$RE/\\2/" <<<"$OVERRIDE")"
+    SCYLLA_RELEASE="$(sed -E "s/$RE/\\3/" <<<"$OVERRIDE")"
+fi
+
 echo "$SCYLLA_VERSION-$SCYLLA_RELEASE"
 mkdir -p build
 echo "$SCYLLA_VERSION" > build/SCYLLA-VERSION-FILE

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -6,11 +6,13 @@ print_usage() {
     echo "build_reloc.sh --clean --nodeps"
     echo "  --clean clean build directory"
     echo "  --nodeps    skip installing dependencies"
+    echo "  --version V  product-version-release string (overriding SCYLLA-VERSION-GEN)"
     exit 1
 }
 
 CLEAN=
 NODEPS=
+VERSION_OVERRIDE=
 while [ $# -gt 0 ]; do
     case "$1" in
         "--clean")
@@ -20,6 +22,10 @@ while [ $# -gt 0 ]; do
         "--nodeps")
             NODEPS=yes
             shift 1
+            ;;
+        "--version")
+            VERSION_OVERRIDE="$2"
+            shift 2
             ;;
         *)
             print_usage
@@ -53,6 +59,6 @@ if [ -z "$NODEPS" ]; then
 fi
 
 mvn -B --file scylla-jmx-parent/pom.xml install
-./SCYLLA-VERSION-GEN
+./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"}
 ./dist/debian/debian_files_gen.py
 scripts/create-relocatable-package.py build/scylla-jmx-package.tar.gz


### PR DESCRIPTION
Instead of using the baked-in values from SCYLLA-VERSION-GEN,
allow passing an override. This will be used by the supermodule
to have an identical product-version-release (especially release,
which contains the git hash) across all packages.