### PR TITLE
dist/debian/debian_files_gen.py: don't ignore permission error on shutil.rmtree()

### DIFF
--- a/dist/debian/debian_files_gen.py
+++ b/dist/debian/debian_files_gen.py
@@ -46,7 +46,8 @@ with open('build/SCYLLA-VERSION-FILE') as f:
 with open('build/SCYLLA-RELEASE-FILE') as f:
     release = f.read().strip()
 
-shutil.rmtree('build/debian/debian', ignore_errors=True)
+if os.path.exists('build/debian/debian'):
+    shutil.rmtree('build/debian/debian')
 shutil.copytree('dist/debian/debian', 'build/debian/debian')
 
 if product != 'scylla':


### PR DESCRIPTION
shutil.rmtree(ignore_errors=True) was for ignores error when directory not exist,
but it also ignores permission error, so we shouldn't use that.
Run os.path.exists() before shutil.rmtree() instead.

See scylladb/scylla#7337