### PR TITLE
Relocatable Package: create product prefixed relocatable archive

### DIFF
--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -6,7 +6,7 @@ Group:          Applications/Databases
 
 License:        AGPLv3
 URL:            http://www.scylladb.com/
-Source0:        scylla-jmx-package.tar.gz
+Source0:        %{reloc_pkg}
 
 BuildArch:      noarch
 BuildRequires:  systemd-units

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -33,6 +33,11 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"})
+# the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
+# related files
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+
 is_redhat_variant() {
     [ -f /etc/redhat-release ]
 }
@@ -50,8 +55,8 @@ if [ "$CLEAN" = "yes" ]; then
     rm -rf build target
 fi
 
-if [ -f build/scylla-jmx-package.tar.gz ]; then
-    rm build/scylla-jmx-package.tar.gz
+if [ -f build/$PRODUCT-jmx-package.tar.gz ]; then
+    rm build/$PRODUCT-jmx-package.tar.gz
 fi
 
 if [ -z "$NODEPS" ]; then
@@ -61,4 +66,4 @@ fi
 mvn -B --file scylla-jmx-parent/pom.xml install
 ./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"}
 ./dist/debian/debian_files_gen.py
-scripts/create-relocatable-package.py build/scylla-jmx-package.tar.gz
+scripts/create-relocatable-package.py build/$PRODUCT-jmx-package.tar.gz

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -30,6 +30,7 @@ mkdir -p "$BUILDDIR"
 tar -C "$BUILDDIR" -xpf $RELOC_PKG scylla-jmx/SCYLLA-RELEASE-FILE scylla-jmx/SCYLLA-RELOCATABLE-FILE scylla-jmx/SCYLLA-VERSION-FILE scylla-jmx/SCYLLA-PRODUCT-FILE scylla-jmx/dist/redhat
 cd "$BUILDDIR"/scylla-jmx
 
+RELOC_PKG_BASENAME=$(basename "$RELOC_PKG")
 SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
 VERSION=$SCYLLA_VERSION-$SCYLLA_RELEASE
@@ -43,6 +44,7 @@ parameters=(
     -D"version $SCYLLA_VERSION"
     -D"release $SCYLLA_RELEASE"
     -D"product $PRODUCT"
+    -D"reloc_pkg $RELOC_PKG_BASENAME"
 )
 
 cp dist/redhat/scylla-jmx.spec $RPMBUILD/SPECS


### PR DESCRIPTION
The build system was hardcoded to produce a package that is
prefixed with scylla instead of the product name. This is not
in line with out CI system requirements and can be also a source
for confusion.
This commit make the packaging system generate a package of
the format: {product}-jmx-package.tar.gz instead of
scylla-jmx-package.tar.gz