### PR TITLE
install.sh: set a valid WorkingDirectory for nonroot offline install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ ExecStart=
 ExecStart=$rprefix/jmx/scylla-jmx \$SCYLLA_JMX_PORT \$SCYLLA_API_PORT \$SCYLLA_API_ADDR \$SCYLLA_JMX_ADDR \$SCYLLA_JMX_FILE \$SCYLLA_JMX_LOCAL \$SCYLLA_JMX_REMOTE \$SCYLLA_JMX_DEBUG
 User=
 Group=
-WorkingDirectory=
+WorkingDirectory=$rprefix
 EOS
 fi
 


### PR DESCRIPTION
In commit 6311525, we set an empty value to WorkDirectory for nonroot.conf
of scylla-jmx.service. It works with ubuntu16, debian9, debian 10. But it
doesn't work with ubuntu 18.

This patch changed the WorkingDirectory of nonroot offline install to
default install directory (/home/scylla-test/scylladb).

Fixes: #151
Signed-off-by: Amos Kong <amos@scylladb.com>