### PR TITLE
StorageService: Add a method to return the uptime

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageService.java
+++ b/src/main/java/org/apache/cassandra/service/StorageService.java
@@ -1749,4 +1749,9 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
         APIClient.set_query_param(queryParams, "cf", APIClient.join(columnFamilies));
         return client.getIntValue("/storage_service/keyspace_scrub/" + keyspaceName, queryParams);
     }
+    @Override
+    public long getUptime() {
+        log("getUptime()");
+        return client.getLongValue("/system/uptime_ms");
+    }
 }

--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -883,4 +883,6 @@ public interface StorageServiceMBean extends NotificationEmitter {
     public List<CompositeData> getSSTableInfo(String keyspace, String table);
 
     public List<CompositeData> getSSTableInfo();
+    /** retun the system uptime */
+    public long getUptime();
 }


### PR DESCRIPTION
Currently, the nodetool uses the jmx server for the uptime, this is
confusing is what we expect is Scylla uptime.

This patch exposes the API uptime using MBean.

Relates to #154

Signed-off-by: Amnon Heiman <amnon@scylladb.com>