### PR TITLE
dist/redhat: stop using systemd macros, call systemctl directly

### DIFF
--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -38,14 +38,20 @@ echo
 fi
 
 %post
-%systemd_post scylla-jmx.service
+if [ $1 -eq 1 ] ; then
+    /usr/bin/systemctl preset scylla-jmx.service ||:
+fi
+
 /usr/bin/systemctl daemon-reload ||:
 
 %preun
-%systemd_preun scylla-jmx.service
+if [ $1 -eq 0 ] ; then
+    /usr/bin/systemctl --no-reload disable scylla-jmx.service ||:
+    /usr/bin/systemctl stop scylla-jmx.service ||:
+fi
 
 %postun
-%systemd_postun scylla-jmx.service
+/usr/bin/systemctl daemon-reload ||:
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
This is v2 of #95, since it's dequeued.

----

Fedora version of systemd macros does not work correctly on CentOS7,
since CentOS7 does not support "file trigger" feature.
Even after 05d4378, scriptlets on old scylla .rpm and new scylla .rpm is
not completely same.

To fix the issue we need to stop using systemd macros, call systemctl
directly.

Fixes #94