### PR TITLE
storage_service: Add a generic toppartitions endpoint

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -34,9 +34,11 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import javax.json.JsonObject;
 import javax.management.NotificationEmitter;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
+import javax.management.openmbean.OpenDataException;
 
 public interface StorageServiceMBean extends NotificationEmitter {
     /**
@@ -883,6 +885,9 @@ public interface StorageServiceMBean extends NotificationEmitter {
     public List<CompositeData> getSSTableInfo(String keyspace, String table);
 
     public List<CompositeData> getSSTableInfo();
+    
     /** retun the system uptime */
     public long getUptime();
+
+    public CompositeData getToppartitions(String sampler, List<String> keyspaceFilters, List<String> tableFilters, int duration, int capacity, int count) throws OpenDataException;
 }


### PR DESCRIPTION
As part of making the toppartitions API more generic
(i.e. being able to consider multiple tables
and keyspaces specified by the user) this commit adds
a JMX endpoint to call the generic Scylla REST API
introduced in [#7864](https://github.com/scylladb/scylla/pull/7864). It has been put inside
storage_service as being now able to query more than
one column family makes it no longer suitable for the
'column_family' group.

Fixes #4520