### PR TITLE
CompactionManager: add the compaction id when available

### DIFF
--- a/src/main/java/org/apache/cassandra/db/compaction/CompactionManager.java
+++ b/src/main/java/org/apache/cassandra/db/compaction/CompactionManager.java
@@ -75,7 +75,7 @@ public class CompactionManager extends MetricsMBean implements CompactionManager
             result.put("keyspace", compaction.getString("ks"));
             result.put("columnfamily", compaction.getString("cf"));
             result.put("unit", compaction.getString("unit"));
-            result.put("compactionId", "<none>");
+            result.put("compactionId", (compaction.containsKey("id"))? compaction.getString("id") : "<none>");
             results.add(result);
         }
         return results;


### PR DESCRIPTION
This patch adds the compaction id in getCompactions if it returns by the
API, if it's not the current behaviour will be used and it will return none.

After this patch a call to nodetool compactionstats -H

Will return:

id                                   compaction type keyspace  table     completed total unit progress
c942bd30-7a62-11eb-84bc-576502584f9a COMPACTION      keyspace1 standard1 1062      8576  keys 12.38%
c9429620-7a62-11eb-8afb-576402584f9a COMPACTION      keyspace1 standard1 972       8448  keys 11.51%
Active compaction remaining time :   0h00m00s

Fixes scylladb/scylla#7927

Signed-off-by: Amnon Heiman <amnon@scylladb.com>