### PR TITLE
dist/redhat: add support SLES

### DIFF
--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -10,7 +10,8 @@ Source0:        %{reloc_pkg}
 
 BuildArch:      noarch
 BuildRequires:  systemd-units
-Requires:       %{product}-server java-1.8.0-openjdk-headless
+Requires:       %{product}-server jre-1.8.0-headless
+AutoReqProv:    no
 
 %description
 


### PR DESCRIPTION
CentOS/RHEL and SLES has differnt package name of opejdk, use common
name of JRE.
Note that using common name of Java package is also useful when user want to
use differnt implementation of JRE for Scylla.

Also, disable AutoReqProv which is mistakenly enabled but required for
cross build rpm.