### PR TITLE
storage_service: Fix getToppartitions to always return both reads and…

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -890,4 +890,6 @@ public interface StorageServiceMBean extends NotificationEmitter {
     public long getUptime();
 
     public CompositeData getToppartitions(String sampler, List<String> keyspaceFilters, List<String> tableFilters, int duration, int capacity, int count) throws OpenDataException;
+    
+    public Map<String, CompositeData> getToppartitions(List<String> samplers, List<String> keyspaceFilters, List<String> tableFilters, int duration, int capacity, int count) throws OpenDataException;
 }


### PR DESCRIPTION
… writes

In line with the previous API, the getToppartitions function returned
results for one specified sampler (reads OR writes). This forced
the user to call the function once for each sampler, which is
suboptimal.
This commit changes the signature so that results for both samplers
are returned and the user can then pick whichever they need.

This is part of the fix for #243 and scylladb/scylla#8459