### PR TITLE
reloc: add arch to relocatable package filename

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -66,4 +66,4 @@ fi
 mvn -B --file scylla-jmx-parent/pom.xml install
 ./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"}
 ./dist/debian/debian_files_gen.py
-scripts/create-relocatable-package.py build/$PRODUCT-jmx-package.tar.gz
+scripts/create-relocatable-package.py build/$PRODUCT-jmx-$(arch)-package.tar.gz


### PR DESCRIPTION
Add architecture name for relocatable packages, to support distributing
both x86_64 version and aarch64 version.

See scylladb/scylla#8675