### PR TITLE
storage_service: takeSnapshot: support the skipFlush option

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageService.java
+++ b/src/main/java/org/apache/cassandra/service/StorageService.java
@@ -552,7 +552,9 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
             APIClient.set_query_param(queryParams, "cf", parts[1]);
         }
         APIClient.set_query_param(queryParams, "kn", APIClient.join(keyspaceNames));
-        // TODO: origin has one recognized option: skip flush. We don't.
+        if (options.containsKey("skipFlush")) {
+            APIClient.set_query_param(queryParams, "sf", options.get("skipFlush"));
+        }
         client.post("/storage_service/snapshots", queryParams);
     }
 


### PR DESCRIPTION
Fixes #167

DTest: test_snapshot_skip_flush

With https://github.com/scylladb/scylla-dtest/pull/2167 (https://github.com/scylladb/scylla-dtest/pull/2167/commits/9b81110787c8e896ba93902dc71d08087734d09d)
and https://github.com/scylladb/scylla/pull/8726 (https://github.com/scylladb/scylla/pull/8726/commits/6c14bea6beca8b8309b6fef64f9c0fda1bbb598c)

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>