### PR TITLE
reloc: increment relocatable package version

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -45,9 +45,9 @@ args = ap.parse_args()
 output = args.dest
 
 ar = tarfile.open(output, mode='w|gz')
-# relocatable package format version = 2
+# relocatable package format version = 3
 with open('build/.relocatable_package_version', 'w') as f:
-    f.write('2\n')
+    f.write('3\n')
 ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
 
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()


### PR DESCRIPTION
This is needed for moving unified package contents to sub-directory.
This package itself has no change.