### PR TITLE
storage_service: support keyspace_validate

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageService.java
+++ b/src/main/java/org/apache/cassandra/service/StorageService.java
@@ -676,6 +676,18 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
     }
 
     /**
+     * Run validation compaction of tables in a single keyspace.
+     */
+    @Override
+    public int validate(String keyspaceName, String... tables)
+            throws IOException, ExecutionException, InterruptedException {
+        log(" validate(String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException");
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+        APIClient.set_query_param(queryParams, "cf", APIClient.join(tables));
+        return client.postInt("/storage_service/keyspace_validate/" + keyspaceName, queryParams);
+    }
+
+    /**
      * Scrub (deserialize + reserialize at the latest version, skipping bad rows
      * if any) the given keyspace. If columnFamilies array is empty, all CFs are
      * scrubbed.
@@ -1709,6 +1721,13 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
             throws IOException, ExecutionException, InterruptedException {
         // "jobs" not (yet) relevant for scylla. (though possibly useful...)
         return forceKeyspaceCleanup(keyspaceName, tables);
+    }
+
+    @Override
+    public int validate(int jobs, String keyspaceName, String... tables)
+            throws IOException, ExecutionException, InterruptedException {
+        // "jobs" not (yet) relevant for scylla. (though possibly useful...)
+        return validate(keyspaceName, tables);
     }
 
     @Override

--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -346,6 +346,19 @@ public interface StorageServiceMBean extends NotificationEmitter {
             throws IOException, ExecutionException, InterruptedException;
 
     /**
+     * Run validation compaction of tables in a single keyspace.
+     * If tables array is empty, all tables are validated.
+     *
+     * This is essentially a read-only version of scrub.
+     */
+    @Deprecated
+    public int validate(String keyspaceName, String... tables)
+            throws IOException, ExecutionException, InterruptedException;
+
+    public int validate(int jobs, String keyspaceName, String... tables)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
      * Scrub (deserialize + reserialize at the latest version, skipping bad rows
      * if any) the given keyspace. If columnFamilies array is empty, all CFs are
      * scrubbed.


### PR DESCRIPTION
Add support for the `keyspace_validate` REST api
that was introduced in scylladb/scylla@b0ef57c83390ada3152568f06769ad76c596cb5e

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>