### PR TITLE
Support `--load-and-stream` option from `nodetool refresh`

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageService.java
+++ b/src/main/java/org/apache/cassandra/service/StorageService.java
@@ -1417,13 +1417,23 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
      *            The parent keyspace name
      * @param cfName
      *            The ColumnFamily name where SSTables belong
+     * @param isLoadAndStream
+     *            Whether or not arbitrary SSTables should be loaded (and streamed to the owning nodes)
      */
     @Override
-    public void loadNewSSTables(String ksName, String cfName) {
-        log(" loadNewSSTables(String ksName, String cfName)");
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream) {
+        log(" loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)");
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
         queryParams.add("cf", cfName);
+        if (isLoadAndStream) {
+            queryParams.add("load_and_stream", "true");
+        }
         client.post("/storage_service/sstables/" + ksName, queryParams);
+    }
+
+    @Override
+    public void loadNewSSTables(String ksName, String cfName) {
+        loadNewSSTables(ksName, cfName, false);
     }
 
     /**

--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -808,7 +808,16 @@ public interface StorageServiceMBean extends NotificationEmitter {
      *            The parent keyspace name
      * @param cfName
      *            The ColumnFamily name where SSTables belong
+     * @param isLoadAndStream
+     *            Whether or not arbitrary SSTables should be loaded (and streamed to the owning nodes)
      */
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream);
+
+    /**
+     * @deprecated use {@link #loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)} instead.
+     * This is kept for backward compatibility.
+     */
+    @Deprecated
     public void loadNewSSTables(String ksName, String cfName);
 
     /**


### PR DESCRIPTION
This information is translated to {"load_and_stream", "true"} entry in the
POST request to Scylla's HTTP API at `storage_service/sstables/{keyspace}`
endpoint.

More about this feature: scylladb/scylla#7846
Mutually bonded change: scylladb/scylla-tools-java#273
Refs scylladb/scylla-tools-java#253.