### PR TITLE
reloc: stop removing entire $BUILDDIR

### DIFF
--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -26,7 +26,7 @@ while [ $# -gt 0 ]; do
 done
 
 RELOC_PKG=$(readlink -f $RELOC_PKG)
-rm -rf "$BUILDDIR"
+rm -rf "$BUILDDIR"/scylla-package "$BUILDDIR"/scylla-package.orig "$BUILDDIR"/debian
 mkdir -p "$BUILDDIR"/scylla-package
 tar -C "$BUILDDIR"/scylla-package -xpf $RELOC_PKG
 cd "$BUILDDIR"/scylla-package


### PR DESCRIPTION
We found that user can mistakenly break system with --builddir option,
something like './reloc/build_deb.sh --builddir /'.
To avoid that we need to stop removing entire $BUILDDIR, remove
directories only we have to clean up before building deb package.

See: https://github.com/scylladb/scylla-python3/pull/23#discussion_r707088453