### PR TITLE
build: replace yum with dnf

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -22,5 +22,5 @@
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt -y install maven openjdk-8-jdk-headless
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    yum install -y maven java-1.8.0-openjdk-devel
+    dnf install -y maven java-1.8.0-openjdk-devel
 fi


### PR DESCRIPTION
dnf has replaced yum on Fedora and CentOS. On modern versions of Fedora,
you have to install an extra package to get the old name working, so
avoid that inconvenience and use dnf directly.