### PR TITLE
Update jackson dependency

### DIFF
--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -12,7 +12,8 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.12.6</jackson.version>
+        <jackson.databind.version>2.12.6.1</jackson.databind.version>
     </properties>
 
     <dependencies>
@@ -69,7 +70,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
Update jackson dependency to a newer version without any known
vulnerabilities. I have checked changelogs of all versions between
2.12.1 and 2.12.6.1, and none of the changes were potentially
problematic (consistent of minor fixes, etc).

2.12.6.1 version of jackson-databind is compatible with 2.12.6 versions
of other jackson packages.