### PR TITLE
install.sh: add --without-systemd option

### DIFF
--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -45,9 +45,9 @@ args = ap.parse_args()
 output = args.dest
 
 ar = tarfile.open(output, mode='w|gz')
-# relocatable package format version = 2
+# relocatable package format version = 2.2
 with open('build/.relocatable_package_version', 'w') as f:
-    f.write('2\n')
+    f.write('2.2\n')
 ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
 
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()


### PR DESCRIPTION
Since we fail to write files to $USER/.config on Jenkins jobs, we need
an option to skip installing systemd units.
Let's add --without-systemd to do that.

See scylladb/scylla-dtest#2819

----

This is jmx part of scylladb/scylla#11345