### PR TITLE
Support `--primary-replica-only` option from `nodetool refresh`

### DIFF
--- a/src/main/java/org/apache/cassandra/service/StorageService.java
+++ b/src/main/java/org/apache/cassandra/service/StorageService.java
@@ -1427,21 +1427,26 @@ public class StorageService extends MetricsMBean implements StorageServiceMBean,
      *            The ColumnFamily name where SSTables belong
      * @param isLoadAndStream
      *            Whether or not arbitrary SSTables should be loaded (and streamed to the owning nodes)
+     * @param isPrimaryReplicaOnly
+     *            Load the sstables and stream to primary replica node that owns the data
      */
     @Override
-    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream) {
-        log(" loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)");
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly) {
+        log(" loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly)");
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
         queryParams.add("cf", cfName);
         if (isLoadAndStream) {
             queryParams.add("load_and_stream", "true");
+        }
+        if (isPrimaryReplicaOnly) {
+            queryParams.add("primary_replica_only", "true");
         }
         client.post("/storage_service/sstables/" + ksName, queryParams);
     }
 
     @Override
     public void loadNewSSTables(String ksName, String cfName) {
-        loadNewSSTables(ksName, cfName, false);
+        loadNewSSTables(ksName, cfName, false, false);
     }
 
     /**

--- a/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/main/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -813,11 +813,13 @@ public interface StorageServiceMBean extends NotificationEmitter {
      *            The ColumnFamily name where SSTables belong
      * @param isLoadAndStream
      *            Whether or not arbitrary SSTables should be loaded (and streamed to the owning nodes)
+     * @param isPrimaryReplicaOnly
+     *            Load the sstables and stream to primary replica node that owns the data
      */
-    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream);
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly);
 
     /**
-     * @deprecated use {@link #loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)} instead.
+     * @deprecated use {@link #loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly)} instead.
      * This is kept for backward compatibility.
      */
     @Deprecated


### PR DESCRIPTION
This is a follow up of commit 658818b2d0b91d56021b883cbfb3ed9b5797e548 to add the --primary-replica-only option to refresh.