### PR TITLE
use OpenJDK 11 instead of OpenJDK 8

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -20,7 +20,7 @@
 . /etc/os-release
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
-    apt -y install maven openjdk-8-jdk-headless
+    apt -y install maven openjdk-11-jdk-headless
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y maven java-1.8.0-openjdk-headless
+    dnf install -y maven java-11-openjdk-headless
 fi

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -22,5 +22,5 @@
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt -y install maven openjdk-8-jdk-headless
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y maven java-1.8.0-openjdk-devel
+    dnf install -y maven java-1.8.0-openjdk-headless
 fi

--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ if ! $packaging; then
     . /etc/os-release
     case "$ID" in
         ubuntu|debian)
-            for version in "8" "11"; do
+            for version in "11" "8"; do
                 java=$(dpkg -L openjdk-${version}-jre-headless | grep '/java$')
                 if [ -n "$java" ]; then
                     break
@@ -98,7 +98,7 @@ if ! $packaging; then
             done
             ;;
         fedora|centos)
-            for version in "1.8.0" "11"; do
+            for version in "11" "1.8.0"; do
                 java=$(rpm -ql java-${version}-openjdk-headless | grep '/java$')
                 if [ -n "$java" ]; then
                     break


### PR DESCRIPTION
in hope to alleviate the pain of #194, this series enables us to 

- install OpenJDK 11 instead of OpenJDK 8 in `install-dependencies.sh`
- add symbolic link to java provided by OpenJDK 11 if it is available, and use the one from OpenJDK 8 as a fallback

Refs #194