### PR TITLE
install.sh: point java to /usr/bin/java

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,7 @@ check_usermode_support() {
     [ -n "$user" ]
 }
 
+java=/usr/bin/java
 if ! $packaging; then
     has_java=false
     . /etc/os-release


### PR DESCRIPTION
this should address the regression introduced by
da69e8b2c793af269c23154ee80372faa9955283, as we do pass --package when cooking rpm and deb packages, in which case, $java is not set after that offending commit. and before da69e8b2c7, $java defaults to /usr/bin/java, let's restore that behavior.