### PR TITLE
dist/redhat: support jre 11 instead of jre 8

### DIFF
--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -10,7 +10,7 @@ Source0:        %{reloc_pkg}
 
 BuildArch:      noarch
 BuildRequires:  systemd-units
-Requires:       %{product}-server jre-1.8.0-headless
+Requires:       %{product}-server jre-11-headless
 AutoReqProv:    no
 
 %description

--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -10,7 +10,8 @@ Source0:        %{reloc_pkg}
 
 BuildArch:      noarch
 BuildRequires:  systemd-units
-Requires:       %{product}-server jre-11-headless
+Requires:       %{product}-server
+Requires:       jre-11-headless
 AutoReqProv:    no
 
 %description


### PR DESCRIPTION
this change fixes the dependency required by scylla-jmx's rpm package.

it is part of the series preparing for jre 11. as we are observing
crashes in JVM provided by OpenJDK 8, see https://github.com/scylladb/scylla-jmx/pull/193. since OpenJDK 8
is aged and only security bugs are accepted now. let's move over to
OpenJDK 11 for a better supported Java platform. since we've already
changed jdk8 to jdk 11 in https://github.com/scylladb/scylla-jmx/commit/19097f2d73d0c42e60f35d3d1fa4d231cfd4809b.
and install-dependencies.sh is used both for preparing developer's
environment and for setting up the dbuild docker image, which is
used for running dtest also in our CI. we need to update scylla-jmx's
rpm accordingly, otherwise the rpm package won't install in the
container setup using the dbuild image once it is updated with the
latest scylla-jmx's install-dependencies.sh. please note, debian/control
already depends on openjdk-11-jre as an alternative of openjdk-8-jre,
so we are fine.

please note, jre-11-headless is provided by java-11-openjdk-headless.