### PR TITLE
install.sh: do not fail if jre-11 is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,11 @@ if ! $packaging; then
     case "$ID" in
         ubuntu|debian)
             for version in "11" "8"; do
-                java=$(dpkg -L openjdk-${version}-jre-headless | grep '/java$')
+                pkg_name=openjdk-${version}-jre-headless
+                if ! dpkg-query --status ${pkg_name}; then
+                    continue
+                fi
+                java=$(dpkg -L ${pkg_name} | grep '/java$')
                 if [ -n "$java" ]; then
                     break
                 fi
@@ -100,7 +104,11 @@ if ! $packaging; then
             ;;
         fedora|centos)
             for version in "11" "1.8.0"; do
-                java=$(rpm -ql java-${version}-openjdk-headless | grep '/java$')
+                pkg_name=java-${version}-openjdk-headless
+                if ! rpm --quiet -q ${pkg_name}; then
+                    continue
+                fi
+                java=$(rpm -ql ${pkg_name} | grep '/java$')
                 if [ -n "$java" ]; then
                     break
                 fi


### PR DESCRIPTION
before this change, `install.sh` errors out if openjdk-11 is not installed, because `dpkg -L` and `rpm -ql` fail if the package being queried is not installed at all. but this is not the behavior by design, we want to continue searching for openjdk-8, and fall back to /usr/bin/java.

so, in this change, we check if the specified package is installed before listing its content.

this problem was surfaced by
https://github.com/scylladb/scylladb/issues/13414, but the issue should be fixed by installing openjdk-11 first.

Refs https://github.com/scylladb/scylladb/issues/13414
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>