### PR TITLE
metrics: EstimatedHistogram::getValues() returns bucketOffsets

### DIFF
--- a/src/main/java/org/apache/cassandra/metrics/MetricsRegistry.java
+++ b/src/main/java/org/apache/cassandra/metrics/MetricsRegistry.java
@@ -475,7 +475,7 @@ public class MetricsRegistry {
 
         @Override
         public long[] getValues() {
-            return buckets;
+            return bucketOffsets;
         }
 
         /**


### PR DESCRIPTION
EstimatedHistogram is expected to return number of sstables as its value, but it returns number of sstables reads.

EstimatedHistogram::getValues() returns bucketOffsets which contains the number of sstables.

Fixes: #199.