### PR TITLE
install.sh: remove "echo done"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -166,5 +166,3 @@ if $nonroot; then
 elif ! $without_systemd && ! $packaging; then
     systemctl --system daemon-reload
 fi
-
-echo done


### PR DESCRIPTION
it was added for debugging in
08a6993750bb75102241b29937f17dd3a8c50ac1 . and it does not help in production. so let's drop it.