### PR TITLE
install.sh: do not create /usr/scylla/jmx in nonroot mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,6 @@ if ! $nonroot; then
 fi
 
 if $nonroot; then
-    install -m755 -d "$rusr"/lib/scylla/jmx
     sed -i -e "s#/var/lib/scylla#$rprefix#g" "$rsysconfdir"/scylla-jmx
     sed -i -e "s#/etc/scylla#$rprefix/etc/scylla#g" "$rsysconfdir"/scylla-jmx
     sed -i -e "s#/opt/scylladb/jmx#$rprefix/jmx#g" "$rsysconfdir"/scylla-jmx


### PR DESCRIPTION
in 08a6993750bb75102241b29937f17dd3a8c50ac1,
`install -m755 -d "$rusr"/lib/scylla/jmx` was added in the nonroot mode. this was wrong. and should only be added for the root mode, as in nonroot mode, we only have the write access to `$rprefix`, and `$ruse` is only valid in the non "nonroot" mode, where the script installs the package with the root user privileged to the system.

so, in this change, this step is dropped, as it is just wrong.