### PR TITLE
treewide: build jar which targets jdk-11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <name>Scylla JMX</name>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
     </properties>	    
 
     <dependencies>
@@ -57,6 +57,16 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs combine.children="append">
+                        <arg>--add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED</arg>
+                        <arg>--add-exports=java.management/com.sun.jmx.interceptor=ALL-UNNAMED</arg>
+                    </compilerArgs>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/scylla-apiclient/dependency-reduced-pom.xml
+++ b/scylla-apiclient/dependency-reduced-pom.xml
@@ -17,8 +17,8 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 </project>
 

--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -10,8 +10,8 @@
     <name>Scylla REST API client</name>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <jackson.version>2.12.6</jackson.version>
         <jackson.databind.version>2.12.6.1</jackson.databind.version>
     </properties>


### PR DESCRIPTION
since we've moved to OpenJDK-11, let's build the jar targeting JDK-11.

the `--add-exports` change was created after referencing
https://docs.oracle.com/en/java/javase/16/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-2F61F3A9-0979-46A4-8B49-325BA0EE8B66
without this change, we'd have build failures like
```
[ERROR] /home/kefu/dev/scylladb/tools/jmx/src/main/java/com/scylladb/jmx/utils/APIBuilder.java:[48,19] package com.sun.jmx.interceptor is not visible
[ERROR]   (package com.sun.jmx.interceptor is declared in module java.management, which does not export it)
```

so that the created jar file won't be compatible with JDK-8, this
helps us to identify the places where the JDK-8 is still used.

by passing `-source` to the javac compiler allows us to use the
Java-11 features. despite that we don't have plan to use any of
them, it is still a nice to have.

Refs #206
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>