### PR TITLE
select-java: avoid exec multiple paths 

### DIFF
--- a/scripts/select-java
+++ b/scripts/select-java
@@ -1,43 +1,55 @@
 #!/bin/bash
 
-has_java=false
+function select_java_debian() {
+    for version in "11" "8"; do
+        pkg_name=openjdk-${version}-jre-headless
+        if ! dpkg-query --status ${pkg_name}; then
+            continue
+        fi
+        java=$(dpkg -L ${pkg_name} | grep '/java$')
+        if [ -n "$java" ]; then
+            echo $java
+            return
+        fi
+    done
+}
+
+function select_java_fedora() {
+    for version in "11" "1.8.0"; do
+        pkg_name=java-${version}-openjdk-headless
+        if ! rpm --quiet -q ${pkg_name}; then
+            continue
+        fi
+        java=$(rpm -ql ${pkg_name} | grep '/java$')
+        if [ -n "$java" ]; then
+            echo $java
+            return
+        fi
+    done
+}
+
+function select_java_others() {
+    javaver=$(/usr/bin/java -version 2>&1|head -n1|cut -f 3 -d " ")
+    if [[ "$javaver" =~ ^\"1.8.0 || "$javaver" =~ ^\"11.0. ]]; then
+        echo /usr/bin/java
+    fi
+}
+
 . /etc/os-release
 case "$ID" in
     ubuntu|debian)
-        for version in "11" "8"; do
-            pkg_name=openjdk-${version}-jre-headless
-            if ! dpkg-query --status ${pkg_name}; then
-                continue
-            fi
-            java=$(dpkg -L ${pkg_name} | grep '/java$')
-            if [ -n "$java" ]; then
-                break
-            fi
-        done
+        java=$(select_java_debian)
         ;;
     fedora|centos)
-        for version in "11" "1.8.0"; do
-            pkg_name=java-${version}-openjdk-headless
-            if ! rpm --quiet -q ${pkg_name}; then
-                continue
-            fi
-            java=$(rpm -ql ${pkg_name} | grep '/java$')
-            if [ -n "$java" ]; then
-                break
-            fi
-        done
+        java=$(select_java_fedora)
         ;;
 esac
 if [ -n "$java" ]; then
-    has_java=true
+    : # good
 elif [ -x /usr/bin/java ]; then
-    javaver=$(/usr/bin/java -version 2>&1|head -n1|cut -f 3 -d " ")
-    if [[ "$javaver" =~ ^\"1.8.0 || "$javaver" =~ ^\"11.0. ]]; then
-        java=/usr/bin/java
-        has_java=true
-    fi
+    java=$(select_java_others)
 fi
-if ! $has_java; then
+if [ -z "$java" ]; then
     exit 1
 fi
 

--- a/scripts/select-java
+++ b/scripts/select-java
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 function select_java_debian() {
+    local java
+    local arch
+    arch=$(dpkg --print-architecture)
+
     for version in "11" "8"; do
-        pkg_name=openjdk-${version}-jre-headless
-        if ! dpkg-query --status ${pkg_name}; then
-            continue
-        fi
-        java=$(dpkg -L ${pkg_name} | grep '/java$')
-        if [ -n "$java" ]; then
+        java=/usr/lib/jvm/java-${version}-openjdk-${arch}/bin/java
+        if [ -e $java ]; then
             echo $java
             return
         fi
@@ -15,13 +15,10 @@ function select_java_debian() {
 }
 
 function select_java_fedora() {
+    local java
     for version in "11" "1.8.0"; do
-        pkg_name=java-${version}-openjdk-headless
-        if ! rpm --quiet -q ${pkg_name}; then
-            continue
-        fi
-        java=$(rpm -ql ${pkg_name} | grep '/java$')
-        if [ -n "$java" ]; then
+        java=/usr/lib/jvm/jre-${version}-openjdk/bin/java
+        if [ -e $java ]; then
             echo $java
             return
         fi


### PR DESCRIPTION
both `dpkg -L .. | grep '/java$'` and `rpm -ql .. | grep '/java$`
can return multiple matches. and before this change, we just exec
the returned string even if it could include multiple paths.

after this change, when selecting java for debian and ubuntu,
use the path of `/usr/lib/jvm/java-11-openjdk-${arch}/bin/java` instead.
when selecting java for fedora and centos, we just return the first
path of `/usr/lib/jvm/jre-${version}-openjdk/bin/java` which exists.

this should address the failure like

```
Error: Could not find or load main class .usr.lib.jvm.java-8-openjdk-arm64.bin.java
```
when launching scylla-jmx as a service on a ubuntu box where
openjdk-8-jre-headless is installed, because:

```console
$ dpkg -L openjdk-8-jre-headless | grep '/java$'
/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
/usr/lib/jvm/java-8-openjdk-amd64/bin/java
```
so the second line would be considered as the command line argument
pass to the first line.

Fixes #206