### PR TITLE
dist/debian: drop dependencies on jdk-8

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,7 @@ Rules-Requires-Root: no
 
 Package: %{product}-jmx
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre |oracle-java11-set-default , %{product}-server
+Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-11-jre-headless | openjdk-11-jre |oracle-java11-set-default , %{product}-server
 Description: Scylla JMX server binaries 
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.

--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,9 @@ Rules-Requires-Root: no
 
 Package: %{product}-jmx
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-11-jre-headless | openjdk-11-jre |oracle-java11-set-default , %{product}-server
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default
+Depends: %{product}-server
 Description: Scylla JMX server binaries 
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.


### PR DESCRIPTION
this change mirrors https://github.com/scylladb/scylla-jmx/commit/f89670dfd80ed04860e1098f0fc6ef114793f31b,
since the oldest supported debian and its derivative are debian 10 and
ubuntu 18.04, both of which ship openjdk-11-jre-headless. and
oracle provides oracle-java11-set-default for them. so it's safe
to drop the optional dependencies on openjdk-8 and orcale-java8.

this would ensure that the scylla-jmx deb package's access to
jdk-11.

Fixes https://github.com/scylladb/scylla-jmx/issues/194