### PR TITLE
install.sh: bail out if jdk is not available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,8 +86,9 @@ check_usermode_support() {
 }
 
 if ! $packaging; then
-    if ! script/select-java --version > /dev/null; then
+    if ! ./select-java --version > /dev/null; then
         echo "Please install openjdk-11 or openjdk-8 before running install.sh."
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
in 96adf0ef51ad49b6abb98867f73cf69705f5f3e3, we started using `select-java` for selecting the JRE for running scylla-jmx, but it failed to reference `select-java` with the correct path. as in the unified reloc package, `select-java` is located at `scylla-jmx/select-java`, `install.sh` is located under the same directory. so we should use `./select-java` here.

also, we should error out if the expected JDK is not found. this is the behavior before 96adf0ef51ad49b6abb98867f73cf69705f5f3e3