### PR TITLE
sstableinfo: change the type of generation to string

### DIFF
--- a/src/main/java/org/apache/cassandra/service/SSTableInfo.java
+++ b/src/main/java/org/apache/cassandra/service/SSTableInfo.java
@@ -27,7 +27,7 @@ public class SSTableInfo {
     @XmlJavaTypeAdapter(type = Date.class, value = DateXmlAdapter.class)
     private Date timestamp;
 
-    private long generation;
+    private String generation;
 
     private long level;
 
@@ -90,11 +90,11 @@ public class SSTableInfo {
         this.timestamp = timestamp;
     }
 
-    public long getGeneration() {
+    public String getGeneration() {
         return generation;
     }
 
-    public void setGeneration(long generation) {
+    public void setGeneration(String generation) {
         this.generation = generation;
     }
 


### PR DESCRIPTION
we will allow user to use UUID for the generation (identifier) of a SSTable. So to be compatible to both "long" and an "UUID", let's use "String" for the type of generation. this change requires the change on scylladb side, which should expose the generation as a string also in its "/storage_service/sstable_info" RESTful API.