### PR TITLE
install-dependencies.sh: do not install weak dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -22,5 +22,5 @@
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt -y install maven openjdk-11-jdk-headless
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y maven java-11-openjdk-headless
+    dnf install -y --setopt=install_weak_deps=False maven java-11-openjdk-headless
 fi


### PR DESCRIPTION
Especially for Java, we really do not need the tens of packages and MBs it adds, just because Java apps can be built and use sound and graphics and whatnot.

(Identical PR was sent earlier to scylla-tools-java repo)