### PR TITLE
scylla-apiclient: update several Java dependencies

### DIFF
--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <jackson.version>2.12.6</jackson.version>
-        <jackson.databind.version>2.12.6.1</jackson.databind.version>
+        <jackson.version>2.15.3</jackson.version>
+        <jackson.databind.version>2.15.3</jackson.databind.version>
     </properties>
 
     <dependencies>

--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>32.1.3-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.collections</groupId>

--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.26</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
This PR updates several dependencies which were flagged by security scanners. In particular:

1. Jackson dependencies: `com.fasterxml.jackson.core:jackson-databind` used in the project was
vulnerable to CVE-2022-42003 and CVE-2022-42004 ("HIGH" severity)
2. snakeyaml dependency: `org.yaml:snakeyaml` used in the project was vulnerable to CVE-2022-1471 ("CRITICAL" severity), CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
3. Guava dependency: `com.google.guava` used in the project was vulnerable to CVE-2023-2976 ("HIGH" severity) and CVE-2020-8908

Please note that at the moment there is no reason to believe that those dependency issues could have affected scylla-jmx itself.

This version of JMX was successfully tested through ScyllaDB CI: https://github.com/scylladb/scylladb/pull/15783#issuecomment-1772830026

Fixes #221
Fixes #222
Fixes #223