### PR TITLE
README: replace 0xA0 (NBSP) character with space

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Scylla JMX server implements the Apache Cassandra JMX interface for compatibilit
 To compile JMX server, run:
 
 ```console
-$ mvn --file scylla-jmx-parent/pom.xml package
+$ mvn --file scylla-jmx-parent/pom.xml package
 ```
 
 ## Running


### PR DESCRIPTION
Before the change, the character after `$` was a `0xA0` (NBSP) character, which is rendered incorrectly by some text editors. Replace it with a regular space character.