### PR TITLE
Fix handling of table names with colon characters

### DIFF
--- a/src/main/java/com/scylladb/jmx/utils/APIBuilder.java
+++ b/src/main/java/com/scylladb/jmx/utils/APIBuilder.java
@@ -425,6 +425,16 @@ public class APIBuilder extends MBeanServerBuilder {
             return (a == null) ? b == null : a.equals(b);
         }
 
+        // Unquote result of ObjectName.getKeyProperty(), if it was quoted
+        // by ObjectName.quote().
+        private static String maybe_unquote(String s) {
+            if (s == null || s.charAt(0) != '"') {
+                return s;
+            } else {
+                return ObjectName.unquote(s);
+            }
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
@@ -433,7 +443,7 @@ public class APIBuilder extends MBeanServerBuilder {
             }
             TableMetricParams oo = (TableMetricParams) o;
             return equal(name.getKeyProperty("keyspace"), oo.name.getKeyProperty("keyspace"))
-                    && equal(name.getKeyProperty("scope"), oo.name.getKeyProperty("scope"))
+                    && equal(maybe_unquote(name.getKeyProperty("scope")), maybe_unquote(oo.name.getKeyProperty("scope")))
                     && equal(name.getKeyProperty("name"), oo.name.getKeyProperty("name"))
                     && equal(name.getKeyProperty("type"), oo.name.getKeyProperty("type"));
         }
@@ -453,7 +463,7 @@ public class APIBuilder extends MBeanServerBuilder {
         @Override
         public int hashCode() {
             return safeAdd(hash(name.getKeyProperty("keyspace")),
-                    hash(name.getKeyProperty("scope")),
+                    hash(maybe_unquote(name.getKeyProperty("scope"))),
                     hash(name.getKeyProperty("name")),
                     hash(name.getKeyProperty("type")));
         }

--- a/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java
+++ b/src/main/java/org/apache/cassandra/db/ColumnFamilyStore.java
@@ -162,7 +162,10 @@ public class ColumnFamilyStore extends MetricsMBean implements ColumnFamilyStore
     }
 
     public ColumnFamilyStore(APIClient client, ObjectName name) {
-        this(client, name.getKeyProperty("type"), name.getKeyProperty("keyspace"), name.getKeyProperty("columnfamily"));
+        // The columnfamily values was quote()ed when creating the Objectname
+        // (see getName()), and name.getKeyProperty() returns it still quoted,
+        // so we need to unquote it back here.
+        this(client, name.getKeyProperty("type"), name.getKeyProperty("keyspace"), ObjectName.unquote(name.getKeyProperty("columnfamily")));
     }
 
     /** true if this CFS contains secondary index data */
@@ -183,8 +186,10 @@ public class ColumnFamilyStore extends MetricsMBean implements ColumnFamilyStore
     }
 
     private static ObjectName getName(String type, String keyspace, String name) throws MalformedObjectNameException {
+        // The quote() call below is necessary for the table name because it might contain
+        // a colon (see https://github.com/scylladb/scylla-jmx/issues/226).
         return new ObjectName(
-                "org.apache.cassandra.db:type=" + type + ",keyspace=" + keyspace + ",columnfamily=" + name);
+                "org.apache.cassandra.db:type=" + type + ",keyspace=" + keyspace + ",columnfamily=" + ObjectName.quote(name));
     }
 
 	public static RegistrationChecker createRegistrationChecker() {


### PR DESCRIPTION
As noted in #226, nodetool breaks if a table name contains the colon character. This normally can't happen - CQL table names can only contain alphanumerics and underscores, and the DynamoDB API adds also dashes and dots - but neither allows a colon. But unfortunately, when Alternator has a secondary index (GSI or LSI), the name of the view _does_ get a colon (it looks like "tablename:viewname"). And this confuses JMX, which addresses objects using MBean names (see https://docs.oracle.com/javase/8/docs/api/javax/management/ObjectName.html), where a name that contains a colon needs to be quoted.

This small series fixes two things: First, some internal list of ObjectName objects needs to quote the names it holds to allow the colon character. Second, we should allow the external client - namely, nodetool - to send us a quoted name.

To complete this series I already have patches to two other repositories which I'll send shortly:
1. A patch to scylla-tools-java (i.e., nodetool) to use quoting when sending a table name with a colon to the JMX server.
2. A dtest patch to verify that before these patches, neither "nodetool info" or "nodetool tablestats" work, and after these patches, both work.

