### PR TITLE
dist/debian: do not use substvar of ${shlib:Depends}

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,7 @@ Rules-Requires-Root: no
 
 Package: %{product}-jmx
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends},
+Depends: ${misc:Depends},
          openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default,
          %{product}-server
 Description: Scylla JMX server binaries 


### PR DESCRIPTION
this subvar is exposed by `dpkg-shlibdeps`, which checks executables for their shared library dependencies, and expose them as `shlib:Depends` substitution variable.

but in the case of jmx, in place of executables, we package scylla-jmx-1.0.jar, which is a java jar archive. so we don't need to add dependencies for it.

also, we don't run `dpkg-shlibdeps` at all. that's why dpkg-gencontrol complains like:

```
dpkg-gencontrol: warning: Depends field of package scylla-jmx:
substitution variable ${shlibs:Depends} used, but is not defined
```

so, let's just drop this subst var.