### PR TITLE
scylla-apiclient: drop hk2-locator dependency

### DIFF
--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -25,22 +25,27 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>2.22.1</version>
+            <version>2.27</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>2.27</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>2.27</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.0.1</version>
+            <version>2.1</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
             <version>1.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Drop the dependency of hk2-locator, in order to get rid of javaassist and other 3rd party dependencies of it.

there are two ways to address this problem:

1. bump up the dependencies which depend on hk2-locator to a version which depend on hk2-locator 2.5.0. because hk2-locator 2.5.0 contains a change to drop the unnecessary dependencies which made their way into the BOM. but they should have not.
2. bump up the dependencies which depend on hk2-locator to a version which does not depend on hk2-locator at all.

before this change, per the output of `mvn dependency:tree -Dverbose=true`, we indirectly depend on hk2-locator 2.4.0.

after this change, hk2-locator dependency is dropped by bumping up org.glassfish.jersey.core to the oldest stable version which was released (see https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-common/2.27) after hk2-locator 2.5.0 was released (see
https://mvnrepository.com/artifact/org.glassfish.hk2/hk2-locator/2.5.0-b42), otherwise we still depend on hk2-locator 2.4.0 indirectly.

verified by running

```shell
mvn dependency:tree -Dverbose=true | grep hk2-locator
```
nothing shows up with this change.

Fixes #231
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>