### PR TITLE
dist: support building packages in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+on:
+  push:
+    branches:
+      - master
+      - branch-*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build packages
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: 'maven'
+          cache-dependency-path: 'scylla-jmx-parent/pom.xml'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y devscripts debhelper
+      - name: Build relocatable package
+        run: |
+          ./reloc/build_reloc.sh --nodeps
+          echo "VERSION=$(./SCYLLA-VERSION-GEN)" >> "$GITHUB_ENV"
+      - name: Build RPM
+        run: |
+          ./reloc/build_rpm.sh --reloc-pkg build/scylla-jmx-${VERSION}.noarch.tar.gz
+      - name: Build DEB
+        run: |
+          ./reloc/build_deb.sh --reloc-pkg build/scylla-jmx-${VERSION}.noarch.tar.gz
+      - name: Upload relocatable package
+        uses: actions/upload-artifact@v4
+        with:
+          name: scylla-jmx-relocatable-${{env.VERSION}}
+          path: build/scylla-jmx-*.noarch.tar.gz
+          if-no-files-found: error
+      - name: Upload RPM
+        uses: actions/upload-artifact@v4
+        with:
+          name: scylla-jmx-rpm-${{env.VERSION}}
+          path: build/redhat/RPMS/noarch/scylla-jmx-*.noarch.rpm
+          if-no-files-found: error
+      - name: Upload DEB
+        uses: actions/upload-artifact@v4
+        with:
+          name: scylla-jmx-deb-${{env.VERSION}}
+          path: build/debian/scylla-jmx_*_all.deb
+          if-no-files-found: error
+      - name: Publish packages to release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            build/scylla-jmx-*.noarch.tar.gz
+            build/redhat/RPMS/noarch/scylla-jmx-*.noarch.rpm
+            build/debian/scylla-jmx_*_all.deb

--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 PRODUCT=scylla
 VERSION=666.development

--- a/dist/redhat/scylla-jmx.spec
+++ b/dist/redhat/scylla-jmx.spec
@@ -9,7 +9,6 @@ URL:            http://www.scylladb.com/
 Source0:        %{reloc_pkg}
 
 BuildArch:      noarch
-BuildRequires:  systemd-units
 Requires:       %{product}-server
 Requires:       jre-11-headless
 AutoReqProv:    no

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -20,7 +20,8 @@
 . /etc/os-release
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
-    apt -y install maven openjdk-11-jdk-headless
+    apt-get update
+    apt-get install -y maven openjdk-11-jdk-headless git rpm devscripts debhelper fakeroot dpkg-dev
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y maven java-11-openjdk-headless
+    dnf install -y maven java-11-openjdk-headless git rpm-build devscripts debhelper fakeroot dpkg-dev
 fi

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -45,6 +45,7 @@ parameters=(
     -D"release $SCYLLA_RELEASE"
     -D"product $PRODUCT"
     -D"reloc_pkg $RELOC_PKG_BASENAME"
+    -D"_unitdir /usr/lib/systemd/system"
 )
 
 cp dist/redhat/scylla-jmx.spec $RPMBUILD/SPECS


### PR DESCRIPTION
Support building packages in Github Actions.
This includes to add support building in Ubuntu, since Github Actions only provides Ubuntu based image for Linux build.

Note that we don't use install-dependencies.sh on Github Actions, since we will use preinstalled Java to speed up installing dependencies.