### PR TITLE
scylla-apiclient: add missing license for SBOM report

### DIFF
--- a/scylla-apiclient/pom.xml
+++ b/scylla-apiclient/pom.xml
@@ -7,6 +7,13 @@
     <packaging>jar</packaging>
     <version>1.0</version>
 
+    <licenses>
+        <license>
+        <name>AGPL-3.0</name>
+        <url>http://www.fsf.org/licensing/licenses/agpl-3.0.html</url>
+        </license>
+    </licenses>
+
     <name>Scylla REST API client</name>
 
     <properties>


### PR DESCRIPTION
SBOM report display empty license,
```
type	name	version	licenses
library	scylla-apiclient	1
Since jmx was removed from OSS master, applying this change directly on release branch
```

Fixes: scylladb/scylla-jmx#237