### PR TITLE
version: update scylla-jmx version to: 6.2.0

### DIFF
--- a/SCYLLA-VERSION-GEN
+++ b/SCYLLA-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PRODUCT=scylla
-VERSION=666.development
+VERSION=6.2.0
 
 if test -f version
 then


### PR DESCRIPTION
Now scylla-jmx is not part of scylla main repo, we need to have own version numbers and release tags.
Since we already released Scylla with scylla-jmx until 6.1.x, so we can start new version from 6.2.0.