### PR TITLE
dist: Invoke GitHub Actions correctly when new tag pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - master
       - branch-*
+    tags:
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
We are missing "tags:" on the trigger definition, need to add it.

Fixes #245